### PR TITLE
Apply breadcrumbs across site

### DIFF
--- a/pages/account.tsx
+++ b/pages/account.tsx
@@ -7,6 +7,7 @@ import clientPromise from "@/lib/mongodb";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
+import Breadcrumbs from "@/components/Breadcrumbs";
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const session = await getSession(context);
@@ -80,6 +81,9 @@ export default function AccountPage({ user, orders }: any) {
 
   return (
     <div className="bg-[var(--bg-page)] text-[var(--foreground)] min-h-screen px-4 py-10">
+      <div className="pl-4 pr-4 sm:pl-8 sm:pr-8 mb-6 -mt-2">
+        <Breadcrumbs />
+      </div>
       <div className="max-w-5xl mx-auto space-y-10">
         {/* 👤 Profile Info */}
         <div className="bg-white/10 backdrop-blur p-6 rounded-2xl shadow-lg">

--- a/pages/account/messages.tsx
+++ b/pages/account/messages.tsx
@@ -5,6 +5,7 @@ import { getSession } from "next-auth/react";
 import clientPromise from "@/lib/mongodb";
 import { useState } from "react";
 import Link from "next/link";
+import Breadcrumbs from "@/components/Breadcrumbs";
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const session = await getSession(context);
@@ -43,6 +44,9 @@ export default function AllMessagesPage({ messages }: any) {
 
   return (
     <div className="bg-[var(--bg-page)] text-[var(--foreground)] min-h-screen px-4 py-10">
+      <div className="pl-4 pr-4 sm:pl-8 sm:pr-8 mb-6 -mt-2">
+        <Breadcrumbs />
+      </div>
       <div className="max-w-5xl mx-auto space-y-10">
         {/* 🧭 Page Title */}
         <div className="flex justify-between items-center">

--- a/pages/admin/archived.tsx
+++ b/pages/admin/archived.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import Head from "next/head";
 import Link from "next/link";
 import { useSession } from "next-auth/react";
+import Breadcrumbs from "@/components/Breadcrumbs";
 
 interface Order {
   _id: string;
@@ -126,6 +127,10 @@ export default function ArchivedOrdersPage() {
       <Head>
         <title>Archived Orders | Classy Diamonds</title>
       </Head>
+
+      <div className="pl-2 pr-2 sm:pl-4 sm:pr-4 mb-6 -mt-2">
+        <Breadcrumbs />
+      </div>
 
       <h1 className="text-3xl font-bold mb-6">🛠️ Admin Dashboard</h1>
 

--- a/pages/admin/completed.tsx
+++ b/pages/admin/completed.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import Head from "next/head";
 import Link from "next/link";
 import { useSession } from "next-auth/react";
+import Breadcrumbs from "@/components/Breadcrumbs";
 
 interface Order {
   _id: string;
@@ -134,6 +135,10 @@ export default function CompletedOrdersPage() {
       <Head>
         <title>Completed Orders | Classy Diamonds</title>
       </Head>
+
+      <div className="pl-2 pr-2 sm:pl-4 sm:pr-4 mb-6 -mt-2">
+        <Breadcrumbs />
+      </div>
 
       {/* 🛠️ Admin Dashboard Heading */}
       <h1 className="text-3xl font-bold mb-6">🛠️ Admin Dashboard</h1>

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import Head from "next/head";
 import Link from "next/link";
 import { useSession } from "next-auth/react";
+import Breadcrumbs from "@/components/Breadcrumbs";
 
 interface Order {
   _id: string;
@@ -148,6 +149,10 @@ export default function AdminOrdersPage() {
       <Head>
         <title>Admin Orders | Classy Diamonds</title>
       </Head>
+
+      <div className="pl-2 pr-2 sm:pl-4 sm:pr-4 mb-6 -mt-2">
+        <Breadcrumbs />
+      </div>
 
       <h1 className="text-3xl font-bold mb-6">🛠️ Admin Dashboard</h1>
 

--- a/pages/admin/logs.tsx
+++ b/pages/admin/logs.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import Head from "next/head";
 import Link from "next/link";
 import { useSession } from "next-auth/react";
+import Breadcrumbs from "@/components/Breadcrumbs";
 
 interface AdminLog {
   _id: string;
@@ -104,6 +105,10 @@ export default function AdminLogsPage() {
       <Head>
         <title>Admin Logs | Classy Diamonds</title>
       </Head>
+
+      <div className="pl-2 pr-2 sm:pl-4 sm:pr-4 mb-6 -mt-2">
+        <Breadcrumbs />
+      </div>
 
       <h1 className="text-3xl font-bold mb-6">🛠️ Admin Dashboard</h1>
 

--- a/pages/admin/products.tsx
+++ b/pages/admin/products.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import { useRouter } from "next/router";
 import { getSession } from "next-auth/react";
 import Image from "next/image";
+import Breadcrumbs from "@/components/Breadcrumbs";
 
 // 🚀 Define allowed categories
 type Category =
@@ -222,6 +223,9 @@ export default function AdminProductsPage() {
 
   return (
     <div className="max-w-4xl mx-auto p-6 space-y-6">
+      <div className="mb-4">
+        <Breadcrumbs />
+      </div>
       <h1 className="text-2xl font-bold">🛠️ Manage Products</h1>
 
       {/* ❗ Status Messages */}

--- a/pages/archived.tsx
+++ b/pages/archived.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import Head from "next/head";
 import Link from "next/link";
+import Breadcrumbs from "@/components/Breadcrumbs";
 
 interface Order {
   _id: string;
@@ -94,6 +95,10 @@ export default function ArchivedOrdersPage() {
       <Head>
         <title>Archived Orders | Classy Diamonds</title>
       </Head>
+
+      <div className="pl-2 pr-2 sm:pl-4 sm:pr-4 mb-6 -mt-2">
+        <Breadcrumbs />
+      </div>
 
       <div className="flex justify-between items-center mb-6">
         <h1 className="text-3xl font-bold">🗂 Archived Orders</h1>

--- a/pages/auth.tsx
+++ b/pages/auth.tsx
@@ -8,6 +8,7 @@ import { useRouter } from "next/router";
 import { FcGoogle } from "react-icons/fc";
 import { FiEye, FiEyeOff } from "react-icons/fi";
 import zxcvbn from "zxcvbn"; // 📊 Strength meter library
+import Breadcrumbs from "@/components/Breadcrumbs";
 
 export default function AuthPage() {
   const router = useRouter();
@@ -145,6 +146,9 @@ export default function AuthPage() {
         px-4 pt-8 flex flex-col items-center  /* 💡 Removed min-h-screen and reduced top padding */
       "
     >
+      <div className="self-start pl-4 pr-4 sm:pl-8 sm:pr-8 mb-6 -mt-2">
+        <Breadcrumbs />
+      </div>
       <div className="bg-[var(--bg-nav)] p-8 sm:p-10 rounded-2xl shadow-xl w-full max-w-md">
         {/* Title */}
         <h2 className="text-2xl font-bold mb-4 text-center">

--- a/pages/cart.tsx
+++ b/pages/cart.tsx
@@ -6,6 +6,7 @@ import Head from "next/head";
 import Link from "next/link";
 import { useCart } from "@/context/CartContext";
 import { useState } from "react";
+import Breadcrumbs from "@/components/Breadcrumbs";
 
 export default function CartPage() {
   const { cartItems, removeFromCart, increaseQty, decreaseQty, clearCart } =
@@ -225,6 +226,10 @@ export default function CartPage() {
         <title>Your Cart | Classy Diamonds</title>
         <meta name="description" content="Cart, summary, and checkout." />
       </Head>
+
+      <div className="pl-4 pr-4 sm:pl-8 sm:pr-8 mt-6 mb-6">
+        <Breadcrumbs />
+      </div>
 
       {/* 📦 Main Layout */}
       <main className="flex flex-col lg:flex-row px-4 sm:px-6 pt-24 pb-32 max-w-7xl mx-auto w-full gap-10">

--- a/pages/category/[category]/index.tsx
+++ b/pages/category/[category]/index.tsx
@@ -7,6 +7,7 @@ import Link from "next/link";
 import { useState, useRef } from "react";
 import { useCart } from "@/context/CartContext";
 import { jewelryData } from "@/data/jewelryData"; // static data
+import Breadcrumbs from "@/components/Breadcrumbs";
 
 interface Product {
   _id: string;
@@ -132,6 +133,10 @@ export default function CategoryPage({
           </div>
         </section>
       )}
+
+      <div className="pl-4 pr-4 sm:pl-8 sm:pr-8 mt-6 mb-6">
+        <Breadcrumbs />
+      </div>
 
       {/* 💍 Product Grid Section */}
       <section className="py-20 px-4 sm:px-6 max-w-7xl mx-auto">

--- a/pages/contact.tsx
+++ b/pages/contact.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import { FaPhoneAlt, FaEnvelope } from "react-icons/fa";
 import { useEffect, useState, useRef } from "react";
 import { useRouter } from "next/router";
+import Breadcrumbs from "@/components/Breadcrumbs";
 
 export default function ContactPage() {
   const router = useRouter();
@@ -189,6 +190,10 @@ export default function ContactPage() {
             </p>
           </div>
         </section>
+
+        <div className="pl-4 pr-4 sm:pl-8 sm:pr-8 mt-6 mb-6">
+          <Breadcrumbs />
+        </div>
 
         {/* 🧑‍🏭 About Section */}
         <section className="px-4 sm:px-6 py-16 sm:py-20 max-w-7xl mx-auto">

--- a/pages/custom.tsx
+++ b/pages/custom.tsx
@@ -3,6 +3,8 @@
 import Head from "next/head";
 import Image from "next/image";
 
+import Breadcrumbs from "@/components/Breadcrumbs";
+
 import heroImage from "../public/hero-custom.jpg";
 
 export default function CustomPage() {
@@ -43,6 +45,10 @@ export default function CustomPage() {
           </p>
         </div>
       </section>
+
+      <div className="pl-4 pr-4 sm:pl-8 sm:pr-8 mt-6 mb-6">
+        <Breadcrumbs />
+      </div>
 
       {/* 🧭 How It Works Section */}
       <section className="px-4 sm:px-6 py-16 sm:py-20 max-w-7xl mx-auto">

--- a/pages/jewelry.tsx
+++ b/pages/jewelry.tsx
@@ -10,6 +10,7 @@ import { useState, useRef, useEffect } from "react";
 import { useRouter } from "next/router";
 import clientPromise from "@/lib/mongodb";
 import { GetServerSideProps } from "next";
+import Breadcrumbs from "@/components/Breadcrumbs";
 
 export type ProductType = {
   id: string;
@@ -148,6 +149,10 @@ export default function JewelryPage({ products }: { products: ProductType[] }) {
           </p>
         </div>
       </section>
+
+      <div className="pl-4 pr-4 sm:pl-8 sm:pr-8 mt-6 mb-6">
+        <Breadcrumbs />
+      </div>
 
       {/* 💎 Title & Desktop Filters */}
       <section className="pt-16 pb-8 px-4 sm:px-6 max-w-7xl mx-auto">

--- a/pages/review/[sessionId].tsx
+++ b/pages/review/[sessionId].tsx
@@ -8,6 +8,7 @@ import { useState, FormEvent, useEffect } from "react";
 import { useRouter } from "next/router";
 import Head from "next/head";
 import Link from "next/link";
+import Breadcrumbs from "@/components/Breadcrumbs";
 import { getSession } from "next-auth/react"; // Optional: if you want to restrict to logged-in users
 
 export default function ReviewPage() {
@@ -84,6 +85,9 @@ export default function ReviewPage() {
       </Head>
 
       <main className="min-h-screen bg-white flex flex-col items-center py-12 px-4 sm:px-6 lg:px-8">
+        <div className="w-full mb-6">
+          <Breadcrumbs />
+        </div>
         <div className="max-w-md w-full space-y-6">
           {/* Page Heading */}
           <h1 className="text-3xl font-extrabold text-gray-900 text-center">

--- a/pages/success.tsx
+++ b/pages/success.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import { useCart } from "@/context/CartContext";
+import Breadcrumbs from "@/components/Breadcrumbs";
 
 // ─── Define the shape of the response from /api/admin/order ─────────────────
 interface SingleOrder {
@@ -71,6 +72,10 @@ export default function SuccessPage() {
           content="Order confirmation and thank you page."
         />
       </Head>
+
+      <div className="pl-4 pr-4 sm:pl-8 sm:pr-8 mt-6 mb-6">
+        <Breadcrumbs />
+      </div>
 
       {/* ✅ Confirmation Section */}
       <main className="flex flex-col items-center justify-center flex-grow px-4 pt-28 pb-20 text-center">


### PR DESCRIPTION
## Summary
- import `Breadcrumbs` component and add navigation element across pages
- show breadcrumbs after hero or heading sections to maintain consistent UI

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840923255ac833094c81afb20ec0066