### PR TITLE
Implement search dropdown

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -9,6 +9,16 @@ import { useSession, signOut } from "next-auth/react";
 import { FiUser, FiShoppingCart, FiSearch, FiMenu, FiX } from "react-icons/fi";
 import { useCart } from "@/context/CartContext";
 
+// 📝 Result fields – adjust if your product schema changes
+interface SearchResult {
+  id: string;
+  name: string;
+  price: number;
+  image: string;
+  slug: string;
+  category: string;
+}
+
 const Navbar = () => {
   const router = useRouter();
   const pathname = router.pathname;
@@ -20,6 +30,10 @@ const Navbar = () => {
   const [menuOpen, setMenuOpen] = useState(false);
   const [cartOpen, setCartOpen] = useState(false);
   const [userMenuOpen, setUserMenuOpen] = useState(false);
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
+  const [searchLoading, setSearchLoading] = useState(false);
 
   const cartRef = useRef<HTMLDivElement>(null);
   const userRef = useRef<HTMLDivElement>(null);
@@ -27,6 +41,8 @@ const Navbar = () => {
   const userButtonRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
   const menuButtonRef = useRef<HTMLDivElement>(null);
+  const searchRef = useRef<HTMLDivElement>(null);
+  const searchButtonRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
     const handleScroll = () => setScrolled(window.scrollY > 50);
@@ -46,11 +62,21 @@ const Navbar = () => {
         menuRef.current &&
         !menuRef.current.contains(target) &&
         !menuButtonRef.current?.contains(target);
+      const clickedOutsideSearch =
+        searchRef.current &&
+        !searchRef.current.contains(target) &&
+        !searchButtonRef.current?.contains(target);
 
-      if (clickedOutsideCart && clickedOutsideUser && clickedOutsideMenu) {
+      if (
+        clickedOutsideCart &&
+        clickedOutsideUser &&
+        clickedOutsideMenu &&
+        clickedOutsideSearch
+      ) {
         setCartOpen(false);
         setUserMenuOpen(false);
         setMenuOpen(false);
+        setSearchOpen(false);
       }
     };
 
@@ -70,6 +96,7 @@ const Navbar = () => {
       setMenuOpen(false);
       setCartOpen(false);
       setUserMenuOpen(false);
+      setSearchOpen(false);
     };
 
     router.events.on("routeChangeStart", handleRouteChange);
@@ -101,6 +128,35 @@ const Navbar = () => {
     setCartOpen((prev) => !prev);
     setUserMenuOpen(false);
     setMenuOpen(false);
+  };
+
+  const handleSearchToggle = () => {
+    setSearchOpen((prev) => !prev);
+    setMenuOpen(false);
+    setCartOpen(false);
+    setUserMenuOpen(false);
+  };
+
+  const fetchResults = async (q: string) => {
+    if (!q) {
+      setSearchResults([]);
+      return;
+    }
+    setSearchLoading(true);
+    try {
+      const res = await fetch(`/api/search?q=${encodeURIComponent(q)}`);
+      const data = await res.json();
+      setSearchResults(data);
+    } catch (err) {
+      console.error("Failed to search", err);
+    } finally {
+      setSearchLoading(false);
+    }
+  };
+
+  const handleSearchSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    fetchResults(searchQuery);
   };
 
   return (
@@ -289,14 +345,15 @@ const Navbar = () => {
               )}
             </button>
 
-            {/* 🔍 Search Icon – moved to far right */}
-            <Link
-              href="/search"
+            {/* 🔍 Search Icon – toggles dropdown */}
+            <button
+              ref={searchButtonRef}
+              onClick={handleSearchToggle}
               aria-label="Search"
               className="cursor-pointer hover:text-white hover:scale-105 transition-transform duration-300"
             >
               <FiSearch />
-            </Link>
+            </button>
           </div>
         </div>
       </header>
@@ -432,26 +489,84 @@ const Navbar = () => {
         </div>
       )}
 
+      {/* 🔍 Search Dropdown */}
+      {searchOpen && (
+        <div
+          ref={searchRef}
+          className="fixed right-0 w-80 bg-[#1f2a44]/95 backdrop-blur-sm shadow-lg text-sm text-white z-40 animate-slide-fade-in transition-all duration-300"
+          style={{
+            top: scrolled ? "64px" : "80px",
+            borderRadius: "0 0 0.75rem 0.75rem",
+            padding: "1rem 1.5rem",
+          }}
+        >
+          <form onSubmit={handleSearchSubmit} className="flex mb-3">
+            <input
+              type="text"
+              placeholder="Search products..."
+              value={searchQuery}
+              onChange={(e) => {
+                setSearchQuery(e.target.value);
+                fetchResults(e.target.value);
+              }}
+              className="flex-1 px-3 py-1 rounded-l bg-[#2a374f] text-white"
+            />
+            <button
+              type="submit"
+              className="px-3 py-1 bg-blue-600 rounded-r hover:bg-blue-700"
+            >
+              Go
+            </button>
+          </form>
+          {searchLoading ? (
+            <p className="text-center text-gray-400">Searching...</p>
+          ) : searchResults.length === 0 && searchQuery ? (
+            <p className="text-center text-gray-400">No results.</p>
+          ) : (
+            <ul className="max-h-48 overflow-y-auto space-y-2">
+              {searchResults.map((p) => (
+                <li key={p.id}>
+                  <Link
+                    href={`/category/${p.category}/${p.slug}`}
+                    className="flex items-center gap-2 hover:underline"
+                    onClick={() => setSearchOpen(false)}
+                  >
+                    <img
+                      src={p.image}
+                      alt={p.name}
+                      className="w-10 h-10 object-cover rounded"
+                    />
+                    <span>{p.name}</span>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+
       {/* 🔲 Tap-Off Overlay – Mobile Only */}
-      {(menuOpen || cartOpen || userMenuOpen) && (
+      {(menuOpen || cartOpen || userMenuOpen || searchOpen) && (
         <div
           className="fixed inset-0 z-30 md:hidden"
           onClick={() => {
             setMenuOpen(false);
             setCartOpen(false);
             setUserMenuOpen(false);
+            setSearchOpen(false);
           }}
         />
       )}
 
       {/* 🔲 Tap-Off Overlay – Desktop Only */}
-      {(menuOpen || cartOpen || userMenuOpen) && (
+      {(menuOpen || cartOpen || userMenuOpen || searchOpen) && (
         <div
           className="hidden md:block fixed inset-0 z-30"
           onClick={() => {
             setMenuOpen(false);
             setCartOpen(false);
             setUserMenuOpen(false);
+            setSearchOpen(false);
           }}
         />
       )}

--- a/pages/api/search.ts
+++ b/pages/api/search.ts
@@ -1,0 +1,51 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import clientPromise from "@/lib/mongodb";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== "GET") {
+    res.setHeader("Allow", "GET");
+    return res.status(405).end("Method Not Allowed");
+  }
+
+  const query = ((req.query.q as string) || "").trim();
+  if (!query) {
+    return res.status(200).json([]);
+  }
+
+  try {
+    const client = await clientPromise;
+    const db = client.db();
+    const regex = new RegExp(query, "i");
+
+    // 📝 Modify the fields inside $or if your product schema changes
+    const products = await db
+      .collection("products")
+      .find({
+        $or: [
+          { name: { $regex: regex } },
+          { description: { $regex: regex } },
+          { category: { $regex: regex } },
+        ],
+      })
+      .limit(20)
+      .toArray();
+
+    const mapped = products.map((p: any) => ({
+      id: p._id.toString(),
+      name: p.name,
+      price: p.price,
+      image: p.imageUrl || p.image,
+      slug: p.slug,
+      category: p.category,
+      description: p.description,
+    }));
+
+    return res.status(200).json(mapped);
+  } catch (err) {
+    console.error("Search error:", err);
+    return res.status(500).json({ error: "Failed to search products" });
+  }
+}


### PR DESCRIPTION
## Summary
- remove standalone search page
- add dropdown search bar triggered from navbar icon
- keep search API to query products

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68409a69c5e08330af6148e221e019f8