### PR TITLE
Unify admin nav styling

### DIFF
--- a/pages/admin/archived.tsx
+++ b/pages/admin/archived.tsx
@@ -135,7 +135,7 @@ export default function ArchivedOrdersPage() {
       <h1 className="text-3xl font-bold mb-6">🛠️ Admin Dashboard</h1>
 
       {/* 🔗 Admin Navigation Tabs */}
-      <nav className="flex space-x-6 mb-8 border-b border-[var(--bg-nav)] pb-4 text-white text-sm font-semibold">
+      <nav className="flex space-x-6 mb-8 border-b border-[var(--bg-nav)] pb-4 text-[var(--foreground)] text-sm font-semibold">
         <Link href="/admin" className="hover:text-yellow-300">
           📦 Orders
         </Link>

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -156,7 +156,7 @@ export default function AdminOrdersPage() {
 
       <h1 className="text-3xl font-bold mb-6">🛠️ Admin Dashboard</h1>
 
-      <nav className="$1text-[var(--foreground)]$2">
+      <nav className="flex space-x-6 mb-8 border-b border-[var(--bg-nav)] pb-4 text-[var(--foreground)] text-sm font-semibold">
         <Link href="/admin" className="text-yellow-400">
           📦 Orders
         </Link>
@@ -180,26 +180,26 @@ export default function AdminOrdersPage() {
         <p>No orders found.</p>
       ) : (
         <>
-          <div className="flex flex-col sm:flex-row sm:items-center sm:space-x-4 mb-6">
-            <input
-              type="text"
-              placeholder="Search by name, email, or ID..."
-              className="$1text-[var(--foreground)]$2"
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-            />
-            <input
-              type="date"
-              value={startDate}
-              onChange={(e) => setStartDate(e.target.value)}
-              className="$1text-[var(--foreground)]$2"
-            />
-            <input
-              type="date"
-              value={endDate}
-              onChange={(e) => setEndDate(e.target.value)}
-              className="$1text-[var(--foreground)]$2"
-            />
+      <div className="flex flex-col sm:flex-row sm:items-center sm:space-x-4 mb-6">
+        <input
+          type="text"
+          placeholder="Search by name, email, or ID..."
+          className="w-full sm:w-1/3 mb-2 sm:mb-0 px-4 py-2 rounded bg-[var(--bg-nav)] text-white"
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+        />
+        <input
+          type="date"
+          value={startDate}
+          onChange={(e) => setStartDate(e.target.value)}
+          className="px-2 py-1 rounded bg-[#2e3a58] text-white"
+        />
+        <input
+          type="date"
+          value={endDate}
+          onChange={(e) => setEndDate(e.target.value)}
+          className="px-2 py-1 rounded bg-[#2e3a58] text-white"
+        />
             <button
               onClick={downloadCSV}
               className="bg-green-600 hover:bg-green-700 px-4 py-2 rounded text-sm"

--- a/pages/admin/products.tsx
+++ b/pages/admin/products.tsx
@@ -4,6 +4,8 @@ import { useState, useEffect } from "react";
 import { useRouter } from "next/router";
 import { getSession } from "next-auth/react";
 import Image from "next/image";
+import Head from "next/head";
+import Link from "next/link";
 import Breadcrumbs from "@/components/Breadcrumbs";
 
 // 🚀 Define allowed categories
@@ -220,11 +222,37 @@ export default function AdminProductsPage() {
   };
 
   return (
-    <div className="max-w-4xl mx-auto p-6 space-y-6">
-      <div className="mb-4">
+    <div className="min-h-screen bg-[var(--bg-page)] text-[var(--foreground)] p-6">
+      <Head>
+        <title>Admin Products | Classy Diamonds</title>
+      </Head>
+
+      <div className="pl-2 pr-2 sm:pl-4 sm:pr-4 mb-6 -mt-2">
         <Breadcrumbs />
       </div>
-      <h1 className="text-2xl font-bold">🛠️ Manage Products</h1>
+
+      <h1 className="text-3xl font-bold mb-6">🛠️ Admin Dashboard</h1>
+
+      <nav className="flex space-x-6 mb-8 border-b border-[var(--bg-nav)] pb-4 text-[var(--foreground)] text-sm font-semibold">
+        <Link href="/admin" className="hover:text-yellow-300">
+          📦 Orders
+        </Link>
+        <Link href="/admin/completed" className="hover:text-yellow-300">
+          ✅ Shipped
+        </Link>
+        <Link href="/admin/archived" className="hover:text-yellow-300">
+          🗂 Archived
+        </Link>
+        <Link href="/admin/products" className="text-yellow-400">
+          🛠 Products
+        </Link>
+        <Link href="/admin/logs" className="hover:text-yellow-300">
+          📝 Logs
+        </Link>
+      </nav>
+
+      <div className="max-w-4xl mx-auto space-y-6">
+        <h2 className="text-2xl font-bold">🛠️ Manage Products</h2>
 
       {/* ❗ Status Messages */}
       {status.error && <p className="text-red-500">❌ {status.error}</p>}
@@ -435,6 +463,7 @@ export default function AdminProductsPage() {
       </div>
 
       {/* 🚧 Placeholder for future: pagination, search, CSV export, etc. */}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- match `/admin` nav spacing with `/admin/completed`
- show unified dashboard heading and nav on the products page
- tweak archived page nav color

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841cfc5f3e48330b2ccb300ac11befa