### PR TITLE
Enable auto-scroll to admin edit form

### DIFF
--- a/pages/admin/products.tsx
+++ b/pages/admin/products.tsx
@@ -82,6 +82,16 @@ export default function AdminProductsPage() {
     success: "",
   });
 
+  // 📍 Ref to the edit form for scrolling
+  const editFormRef = useRef<HTMLFormElement | null>(null);
+
+  // 🚚 When a product is selected for editing, scroll to the form
+  useEffect(() => {
+    if (editingProduct) {
+      editFormRef.current?.scrollIntoView({ behavior: "smooth" });
+    }
+  }, [editingProduct]);
+
   // 🧮 Count of featured items currently selected
   //    Derive from rowEdits: count how many existing products are marked featured
   const featuredCount = Object.values(rowEdits).filter(
@@ -343,7 +353,7 @@ export default function AdminProductsPage() {
       {/* ✏️ Edit Product Form */}
       {editingProduct && (
         <form
-
+          ref={editFormRef}
           onSubmit={handleUpdate}
           className="grid grid-cols-1 md:grid-cols-2 gap-4 border p-4 rounded"
         >


### PR DESCRIPTION
## Summary
- scroll to the edit form when selecting a product to edit

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npx tsc -p tsconfig.json` *(fails: many TS errors)*


------
https://chatgpt.com/codex/tasks/task_e_6841debbc1f08330a0105990e025f758