### PR TITLE
Add product links on admin page

### DIFF
--- a/pages/admin/products.tsx
+++ b/pages/admin/products.tsx
@@ -23,6 +23,7 @@ interface AdminProduct {
   _id: string; // MongoDB ID
   skuNumber?: number; // sequential SKU
   name: string;
+  slug: string; // URL slug for product page
   description: string;
   price: number;
   salePrice?: number;
@@ -619,7 +620,14 @@ useEffect(() => {
                         className="object-cover rounded"
                       />
                     </td>
-                    <td className="p-2">{p.name}</td>
+                    <td className="p-2">
+                      <Link
+                        href={`/category/${p.category}/${p.slug}`}
+                        className="hover:text-yellow-300 underline"
+                      >
+                        {p.name}
+                      </Link>
+                    </td>
                     <td className="p-2">
                       <select
                         value={edit.category}


### PR DESCRIPTION
## Summary
- add slug field to the admin product type
- link each product name in admin table to its public product page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841ead30970833090f93ef3ff0755b9