### PR TITLE
Display order numbers

### DIFF
--- a/pages/account.tsx
+++ b/pages/account.tsx
@@ -184,6 +184,12 @@ export default function AccountPage({ user, orders }: any) {
                     >
                       <div className="flex flex-col md:flex-row md:justify-between md:items-center gap-2">
                         <div>
+                          <p className="text-sm text-gray-400">Order #:</p>
+                          <p className="text-sm font-semibold break-all">
+                            #{order.orderNumber ?? "N/A"}
+                          </p>
+                        </div>
+                        <div>
                           <p className="text-sm text-gray-400">Order ID:</p>
                           <p className="text-sm font-semibold break-all">
                             {order.stripeSessionId}

--- a/pages/account/orders.tsx
+++ b/pages/account/orders.tsx
@@ -146,7 +146,13 @@ export default function OrdersPage({
                   <div>
                     <p className="text-sm text-[#cfd2d6]">Order #:</p>
                     <p className="text-sm font-semibold break-all">
-                      #{order.orderNumber} {/* 🆕 Show short orderNumber */}
+                      #{order.orderNumber}
+                    </p>
+                  </div>
+                  <div>
+                    <p className="text-sm text-[#cfd2d6]">Order ID:</p>
+                    <p className="text-sm font-semibold break-all">
+                      {order.stripeSessionId}
                     </p>
                   </div>
                   <div>


### PR DESCRIPTION
## Summary
- show both order number and order ID on account dashboard
- display order ID next to order number in full orders page

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npx tsc -p tsconfig.json` *(fails: missing Next.js type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6841f34957e083308d4e79257ec2d25a