### PR TITLE
Fix shipped page delivered filtering

### DIFF
--- a/pages/admin/completed.tsx
+++ b/pages/admin/completed.tsx
@@ -134,7 +134,7 @@ export default function CompletedOrdersPage() {
   };
 
   const filteredOrders = orders.filter((order) => {
-    if (order.archived) return false;
+    if (order.archived || order.delivered) return false;
 
     const query = searchQuery.toLowerCase();
     const matchQuery =

--- a/pages/api/admin/completed.ts
+++ b/pages/api/admin/completed.ts
@@ -16,7 +16,7 @@ export default async function handler(
     const db = client.db();
     const orders = await db
       .collection("orders")
-      .find({ shipped: true })
+      .find({ shipped: true, delivered: { $ne: true } })
       .sort({ shippedAt: -1 })
       .toArray();
 


### PR DESCRIPTION
## Summary
- exclude delivered orders from admin shipped page
- update shipped API route to ignore delivered records

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6841f4d00ec4833087a944771b056d68