### PR TITLE
Display order numbers

### DIFF
--- a/pages/account.tsx
+++ b/pages/account.tsx
@@ -184,6 +184,12 @@ export default function AccountPage({ user, orders }: any) {
                     >
                       <div className="flex flex-col md:flex-row md:justify-between md:items-center gap-2">
                         <div>
+                          <p className="text-sm text-gray-400">Order #:</p>
+                          <p className="text-sm font-semibold break-all">
+                            #{order.orderNumber ?? "N/A"}
+                          </p>
+                        </div>
+                        <div>
                           <p className="text-sm text-gray-400">Order ID:</p>
                           <p className="text-sm font-semibold break-all">
                             {order.stripeSessionId}

--- a/pages/account/orders.tsx
+++ b/pages/account/orders.tsx
@@ -146,7 +146,13 @@ export default function OrdersPage({
                   <div>
                     <p className="text-sm text-[#cfd2d6]">Order #:</p>
                     <p className="text-sm font-semibold break-all">
-                      #{order.orderNumber} {/* 🆕 Show short orderNumber */}
+                      #{order.orderNumber}
+                    </p>
+                  </div>
+                  <div>
+                    <p className="text-sm text-[#cfd2d6]">Order ID:</p>
+                    <p className="text-sm font-semibold break-all">
+                      {order.stripeSessionId}
                     </p>
                   </div>
                   <div>

--- a/pages/admin/archived.tsx
+++ b/pages/admin/archived.tsx
@@ -15,6 +15,7 @@ interface Order {
   amount: number;
   createdAt: string;
   stripeSessionId: string;
+  orderNumber?: number;
   shippedAt?: string;
   archived?: boolean;
 }
@@ -186,6 +187,9 @@ export default function ArchivedOrdersPage() {
               <h2 className="text-xl font-semibold mb-1">
                 {order.customerName} ({order.customerEmail})
               </h2>
+              <p className="text-sm mb-2 text-gray-300">
+                🔢 Order #: {order.orderNumber ?? "N/A"}
+              </p>
               <p className="text-sm mb-2 text-gray-300">
                 🆔 Order ID: {order.stripeSessionId.slice(-8)}
               </p>

--- a/pages/admin/completed.tsx
+++ b/pages/admin/completed.tsx
@@ -15,6 +15,7 @@ interface Order {
   amount: number;
   createdAt: string;
   stripeSessionId: string;
+  orderNumber?: number;
   shippedAt?: string;
   delivered?: boolean;
   deliveredAt?: string;
@@ -250,6 +251,9 @@ export default function CompletedOrdersPage() {
                 <h2 className="text-xl font-semibold mb-1">
                   {order.customerName} ({order.customerEmail})
                 </h2>
+                <p className="text-sm mb-2 text-gray-300">
+                  🔢 Order #: {order.orderNumber ?? "N/A"}
+                </p>
                 <p className="text-sm mb-2 text-gray-300">
                   🆔 Order ID: {order.stripeSessionId.slice(-8)}
                 </p>

--- a/pages/admin/delivered.tsx
+++ b/pages/admin/delivered.tsx
@@ -15,6 +15,7 @@ interface Order {
   amount: number;
   createdAt: string;
   stripeSessionId: string;
+  orderNumber?: number;
   shippedAt?: string;
   delivered?: boolean;
   deliveredAt?: string;
@@ -230,6 +231,9 @@ export default function DeliveredOrdersPage() {
                 <h2 className="text-xl font-semibold mb-1">
                   {order.customerName} ({order.customerEmail})
                 </h2>
+                <p className="text-sm mb-2 text-gray-300">
+                  🔢 Order #: {order.orderNumber ?? "N/A"}
+                </p>
                 <p className="text-sm mb-2 text-gray-300">
                   🆔 Order ID: {order.stripeSessionId.slice(-8)}
                 </p>

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -15,6 +15,7 @@ interface Order {
   amount: number;
   createdAt: string;
   stripeSessionId: string;
+  orderNumber?: number;
   shipped?: boolean;
   archived?: boolean;
 }
@@ -238,6 +239,9 @@ export default function AdminOrdersPage() {
                 <h2 className="text-xl font-semibold mb-1">
                   {order.customerName} ({order.customerEmail})
                 </h2>
+                <p className="text-sm mb-2 text-gray-300">
+                  🔢 Order #: {order.orderNumber ?? "N/A"}
+                </p>
                 <p className="text-sm mb-2 text-gray-300">
                   🆔 Order ID: {order.stripeSessionId.slice(-8)}
                 </p>

--- a/pages/admin/logs.tsx
+++ b/pages/admin/logs.tsx
@@ -19,6 +19,7 @@ interface OrderDetails {
   amount: number;
   customerAddress: string;
   createdAt: string;
+  orderNumber?: number;
 }
 
 export default function AdminLogsPage() {
@@ -200,6 +201,9 @@ export default function AdminLogsPage() {
                   {expandedOrders[log.orderId] && (
                     <tr className="bg-[#2a374f]">
                       <td colSpan={4} className="px-6 py-4">
+                        <p className="mb-2 text-sm">
+                          🔢 Order #: {expandedOrders[log.orderId].orderNumber ?? "N/A"}
+                        </p>
                         <p className="mb-2 text-sm">
                           📍 Address:{" "}
                           {expandedOrders[log.orderId].customerAddress}


### PR DESCRIPTION
## Summary
- show short order numbers next to order IDs on admin pages
- expose `orderNumber` property in relevant admin page types

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npx tsc -p tsconfig.json` *(fails to compile: missing Next.js and other type defs)*

------
https://chatgpt.com/codex/tasks/task_e_6841f34957e083308d4e79257ec2d25a