### PR TITLE
Add order details to status emails

### DIFF
--- a/lib/emailUtils.ts
+++ b/lib/emailUtils.ts
@@ -1,0 +1,41 @@
+export function buildOrderDetailsHtml(order: any): string {
+  const itemRows = (order.items || [])
+    .map(
+      (item: any) => `
+            <tr>
+              <td style="padding: 8px; border: 1px solid #ddd;">
+                <div style="display: flex; align-items: center; gap: 10px;">
+                  <img src="${item.image}" alt="${item.name}" style="width: 50px; height: 50px; object-fit: cover; border-radius: 4px;" />
+                  <span>${item.name}</span>
+                </div>
+              </td>
+              <td style="padding: 8px; border: 1px solid #ddd;">x${item.quantity}</td>
+              <td style="padding: 8px; border: 1px solid #ddd;">$${(item.price * item.quantity).toFixed(2)}</td>
+            </tr>`
+    )
+    .join("");
+
+  const orderDate = order.createdAt
+    ? new Date(order.createdAt).toLocaleString()
+    : "";
+
+  return `
+    <p><strong>Order ID:</strong> ${order.orderNumber}<br>
+    <strong>Stripe Session:</strong> ${order.stripeSessionId}<br>
+    <strong>Order Date:</strong> ${orderDate}</p>
+
+    <table style="width: 100%; border-collapse: collapse; margin-top: 20px;">
+      <thead>
+        <tr style="background-color: #f2f2f2;">
+          <th align="left" style="padding: 8px; border: 1px solid #ddd;">Item</th>
+          <th align="left" style="padding: 8px; border: 1px solid #ddd;">Quantity</th>
+          <th align="left" style="padding: 8px; border: 1px solid #ddd;">Subtotal</th>
+        </tr>
+      </thead>
+      <tbody>${itemRows}</tbody>
+    </table>
+
+    <p style="margin-top: 20px;"><strong>Shipping to:</strong><br>${order.customerAddress}</p>
+    <p><strong>Total:</strong> $${order.amount.toFixed(2)}</p>
+  `;
+}

--- a/pages/api/delivered.ts
+++ b/pages/api/delivered.ts
@@ -2,6 +2,7 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import clientPromise from "@/lib/mongodb";
 import nodemailer from "nodemailer";
+import { buildOrderDetailsHtml } from "@/lib/emailUtils";
 
 export default async function handler(
   req: NextApiRequest,
@@ -48,11 +49,14 @@ export default async function handler(
       },
     });
 
+    const orderDetails = buildOrderDetailsHtml(order);
+
     const html = `
       <div style="font-family: Arial, sans-serif; color: #333; max-width: 600px; margin: auto;">
         <h2 style="color: #1f2a44;">Your Order Was Delivered</h2>
         <p>Hi ${order.customerName},</p>
         <p>We have confirmed that your order has been delivered. We hope you enjoy your purchase!</p>
+        ${orderDetails}
         <p style="margin-top: 30px; font-size: 14px;">
           If you have any questions, reply to this email or contact
           <a href="mailto:support@classydiamonds.com">support@classydiamonds.com</a>

--- a/pages/api/shipped.ts
+++ b/pages/api/shipped.ts
@@ -3,6 +3,7 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import nodemailer from "nodemailer";
 import clientPromise from "@/lib/mongodb";
+import { buildOrderDetailsHtml } from "@/lib/emailUtils";
 
 export default async function handler(
   req: NextApiRequest,
@@ -54,13 +55,14 @@ export default async function handler(
       },
     });
 
+    const orderDetails = buildOrderDetailsHtml(order);
+
     const html = `
       <div style="font-family: Arial, sans-serif; color: #333; max-width: 600px; margin: auto;">
         <h2 style="color: #1f2a44;">Your Order Has Shipped! 📦</h2>
         <p>Hi ${order.customerName},</p>
         <p>Your order has been carefully packaged and handed off for delivery.</p>
-        <p><strong>Shipping to:</strong><br>${order.customerAddress}</p>
-        <p><strong>Total:</strong> $${order.amount.toFixed(2)}</p>
+        ${orderDetails}
 
         <p style="margin-top: 30px; font-size: 14px;">
           If you have any questions, reply to this email or contact

--- a/pages/api/tracking.ts
+++ b/pages/api/tracking.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import nodemailer from "nodemailer";
 import clientPromise from "@/lib/mongodb";
+import { buildOrderDetailsHtml } from "@/lib/emailUtils";
 
 export default async function handler(
   req: NextApiRequest,
@@ -58,6 +59,8 @@ export default async function handler(
     const urlBase = carrierUrls[carrier] || "";
     const trackingLink = urlBase ? `${urlBase}${trackingNumber}` : trackingNumber;
 
+    const orderDetails = buildOrderDetailsHtml(order);
+
     const html = `
       <div style="font-family: Arial, sans-serif; color: #333; max-width: 600px; margin: auto;">
         <h2 style="color: #1f2a44;">Your Tracking Number</h2>
@@ -65,6 +68,7 @@ export default async function handler(
         <p>Your order has been shipped. Here is your tracking number:</p>
         <p><strong>${trackingNumber}</strong></p>
         ${urlBase ? `<p><a href="${trackingLink}">Track Your Package</a></p>` : ""}
+        ${orderDetails}
         <p style="margin-top: 30px; font-size: 14px;">
           If you have any questions, reply to this email or contact
           <a href="mailto:support@classydiamonds.com">support@classydiamonds.com</a>


### PR DESCRIPTION
## Summary
- share order email HTML in a utility
- include full order info in shipping, tracking, and delivered notifications

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841fc16a7a88330a82c831be2071ab6