### PR TITLE
Fix delivered status display

### DIFF
--- a/pages/account/orders.tsx
+++ b/pages/account/orders.tsx
@@ -166,12 +166,18 @@ export default function OrdersPage({
                     <p className="text-sm text-[#cfd2d6]">Status:</p>
                     <span
                       className={`text-xs font-bold px-3 py-1 rounded-full inline-block ${
-                        order.shipped
+                        order.delivered
+                          ? "bg-blue-500 text-[var(--bg-page)]"
+                          : order.shipped
                           ? "bg-green-500 text-[var(--bg-page)]"
                           : "bg-yellow-500 text-black"
                       }`}
                     >
-                      {order.shipped ? "Shipped" : "Processing"}
+                      {order.delivered
+                        ? "Delivered"
+                        : order.shipped
+                        ? "Shipped"
+                        : "Processing"}
                     </span>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- show `Delivered` status on orders page when order is delivered

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841fdd97a9c8330a48490ffb9862874