### PR TITLE
Set 15-minute session expiry

### DIFF
--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -74,6 +74,8 @@ export const authOptions: AuthOptions = {
   // 📨 Use JWT sessions
   session: {
     strategy: "jwt" as const,
+    // Limit session lifetime to 15 minutes for improved security
+    maxAge: 15 * 60,
   },
 
   // 🔄 Callbacks to modify token & session


### PR DESCRIPTION
## Summary
- limit NextAuth session lifetime to fifteen minutes for security

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846f409556083309c9ff6ec101a4d93