### PR TITLE
Improve admin logs display

### DIFF
--- a/pages/admin/archived.tsx
+++ b/pages/admin/archived.tsx
@@ -54,7 +54,11 @@ export default function ArchivedOrdersPage() {
       const res = await fetch("/api/admin/archived", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ orderId, restore: true }),
+        body: JSON.stringify({
+          orderId,
+          restore: true,
+          adminName: session?.user?.firstName,
+        }),
       });
       const result = await res.json();
       if (res.ok) fetchArchivedOrders();

--- a/pages/admin/completed.tsx
+++ b/pages/admin/completed.tsx
@@ -63,7 +63,7 @@ export default function CompletedOrdersPage() {
       const res = await fetch("/api/delivered", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ orderId }),
+        body: JSON.stringify({ orderId, adminName: session?.user?.firstName }),
       });
       const result = await res.json();
       if (res.ok) fetchCompletedOrders();
@@ -88,6 +88,7 @@ export default function CompletedOrdersPage() {
           orderId,
           trackingNumber: input.trackingNumber,
           carrier: input.carrier,
+          adminName: session?.user?.firstName,
         }),
       });
       const result = await res.json();
@@ -111,7 +112,7 @@ export default function CompletedOrdersPage() {
       const res = await fetch("/api/admin/archived", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ orderId }),
+        body: JSON.stringify({ orderId, adminName: session?.user?.firstName }),
       });
       const result = await res.json();
       if (res.ok) fetchCompletedOrders();

--- a/pages/admin/delivered.tsx
+++ b/pages/admin/delivered.tsx
@@ -60,7 +60,7 @@ export default function DeliveredOrdersPage() {
       const res = await fetch("/api/admin/archived", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ orderId }),
+        body: JSON.stringify({ orderId, adminName: session?.user?.firstName }),
       });
       const result = await res.json();
       if (res.ok) fetchDeliveredOrders();

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -57,7 +57,7 @@ export default function AdminOrdersPage() {
       const res = await fetch("/api/shipped", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ orderId }),
+        body: JSON.stringify({ orderId, adminName: session?.user?.firstName }),
       });
       const result = await res.json();
       if (res.ok) fetchOrders();
@@ -77,7 +77,7 @@ export default function AdminOrdersPage() {
       const res = await fetch("/api/admin/archived", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ orderId }),
+        body: JSON.stringify({ orderId, adminName: session?.user?.firstName }),
       });
       const result = await res.json();
       if (res.ok) fetchOrders();

--- a/pages/api/admin/archived.ts
+++ b/pages/api/admin/archived.ts
@@ -52,7 +52,7 @@ export default async function handler(
         orderId,
         action: restore ? "restore" : "archive",
         timestamp: new Date(),
-        performedBy: "admin", // replace later with session.user.email
+        performedBy: req.body.adminName || "unknown",
       });
 
       return res.status(200).json({ success: true });

--- a/pages/api/delivered.ts
+++ b/pages/api/delivered.ts
@@ -12,7 +12,7 @@ export default async function handler(
     return res.status(405).json({ error: "Method not allowed" });
   }
 
-  const { orderId, adminEmail } = req.body;
+  const { orderId, adminName } = req.body;
   if (!orderId) {
     return res.status(400).json({ error: "Missing orderId" });
   }
@@ -38,7 +38,7 @@ export default async function handler(
       orderId,
       action: "delivered",
       timestamp: new Date(),
-      performedBy: adminEmail || "unknown",
+      performedBy: adminName || "unknown",
     });
 
     const transporter = nodemailer.createTransport({

--- a/pages/api/shipped.ts
+++ b/pages/api/shipped.ts
@@ -13,7 +13,7 @@ export default async function handler(
     return res.status(405).json({ error: "Method not allowed" });
   }
 
-  const { orderId, adminEmail } = req.body;
+  const { orderId, adminName } = req.body;
 
   if (!orderId) {
     return res.status(400).json({ error: "Missing orderId" });
@@ -43,7 +43,7 @@ export default async function handler(
       orderId,
       action: "shipped",
       timestamp: new Date(),
-      performedBy: adminEmail || "unknown",
+      performedBy: adminName || "unknown",
     });
 
     // ✅ Send shipping email

--- a/pages/api/tracking.ts
+++ b/pages/api/tracking.ts
@@ -11,7 +11,7 @@ export default async function handler(
     return res.status(405).json({ error: "Method not allowed" });
   }
 
-  const { orderId, trackingNumber, carrier, adminEmail } = req.body;
+  const { orderId, trackingNumber, carrier, adminName } = req.body;
   if (!orderId || !trackingNumber) {
     return res.status(400).json({ error: "Missing orderId or trackingNumber" });
   }
@@ -39,7 +39,7 @@ export default async function handler(
       orderId,
       action: "tracking",
       timestamp: new Date(),
-      performedBy: adminEmail || "unknown",
+      performedBy: adminName || "unknown",
     });
 
     const transporter = nodemailer.createTransport({


### PR DESCRIPTION
## Summary
- fetch order numbers in admin log API
- store admin name in log entries
- send adminName in admin panel actions
- show order # in logs table
- expand each log individually and show order history

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846fd5039b88330bdb4d3e39e8cdf3a