### PR TITLE
Fix admin name logging

### DIFF
--- a/pages/admin/archived.tsx
+++ b/pages/admin/archived.tsx
@@ -60,7 +60,7 @@ export default function ArchivedOrdersPage() {
         
 
 
-        body: JSON.stringify({ orderId, restore: true, adminName: session?.user?.firstName }),
+        body: JSON.stringify({ orderId, restore: true, adminName }),
 
 
       });

--- a/pages/admin/completed.tsx
+++ b/pages/admin/completed.tsx
@@ -65,11 +65,7 @@ export default function CompletedOrdersPage() {
       const res = await fetch("/api/delivered", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-
-
-        body: JSON.stringify({ orderId, adminName: session?.user?.firstName }),
-
-
+        body: JSON.stringify({ orderId, adminName }),
       });
       const result = await res.json();
       if (res.ok) fetchCompletedOrders();
@@ -96,11 +92,7 @@ export default function CompletedOrdersPage() {
           orderId,
           trackingNumber: input.trackingNumber,
           carrier: input.carrier,
-
-
-          adminName: session?.user?.firstName,
-
-
+          adminName,
         }),
       });
       const result = await res.json();
@@ -126,11 +118,7 @@ export default function CompletedOrdersPage() {
       const res = await fetch("/api/admin/archived", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-
-
-        body: JSON.stringify({ orderId, adminName: session?.user?.firstName }),
-
-
+        body: JSON.stringify({ orderId, adminName }),
       });
       const result = await res.json();
       if (res.ok) fetchCompletedOrders();

--- a/pages/admin/delivered.tsx
+++ b/pages/admin/delivered.tsx
@@ -62,11 +62,7 @@ export default function DeliveredOrdersPage() {
       const res = await fetch("/api/admin/archived", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-
-
-        body: JSON.stringify({ orderId, adminName: session?.user?.firstName }),
-
-
+        body: JSON.stringify({ orderId, adminName }),
       });
       const result = await res.json();
       if (res.ok) fetchDeliveredOrders();

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -59,11 +59,7 @@ export default function AdminOrdersPage() {
       const res = await fetch("/api/shipped", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-
-
-        body: JSON.stringify({ orderId, adminName: session?.user?.firstName }),
-
-
+        body: JSON.stringify({ orderId, adminName }),
       });
       const result = await res.json();
       if (res.ok) fetchOrders();
@@ -85,11 +81,7 @@ export default function AdminOrdersPage() {
       const res = await fetch("/api/admin/archived", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-
-
-        body: JSON.stringify({ orderId, adminName: session?.user?.firstName }),
-
-
+        body: JSON.stringify({ orderId, adminName }),
       });
       const result = await res.json();
       if (res.ok) fetchOrders();


### PR DESCRIPTION
## Summary
- ensure adminName uses fallback `name` for Google signups
- fix admin actions to send computed adminName when archiving, shipping, delivering, and updating tracking

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847153498688330816ff951bc7f8c5f