### PR TITLE
Implement auto logout after 15 minutes idle

### DIFF
--- a/components/AutoLogout.tsx
+++ b/components/AutoLogout.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useRef } from "react";
+import { signOut } from "next-auth/react";
+
+const INACTIVITY_LIMIT = 15 * 60 * 1000; // 15 minutes in ms
+
+const AutoLogout = () => {
+  const timerRef = useRef<NodeJS.Timeout>();
+
+  useEffect(() => {
+    const resetTimer = () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => {
+        signOut({ callbackUrl: "/" });
+      }, INACTIVITY_LIMIT);
+    };
+
+    const events: (keyof WindowEventMap)[] = [
+      "mousemove",
+      "mousedown",
+      "keypress",
+      "scroll",
+      "touchstart",
+    ];
+
+    events.forEach((event) => window.addEventListener(event, resetTimer));
+
+    resetTimer();
+
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      events.forEach((event) =>
+        window.removeEventListener(event, resetTimer)
+      );
+    };
+  }, []);
+
+  return null;
+};
+
+export default AutoLogout;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -8,6 +8,7 @@ import { SessionProvider } from "next-auth/react";
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
 import { CartProvider } from "@/context/CartContext";
+import AutoLogout from "@/components/AutoLogout";
 
 // ⚡ Import the SpeedInsights component (no HOC wrapper needed)
 import { SpeedInsights } from "@vercel/speed-insights/next";
@@ -46,6 +47,8 @@ function App({ Component, pageProps: { session, ...pageProps } }: AppProps) {
       <CartProvider>
         {/* 🌐 Navbar */}
         <Navbar />
+        {/* ⏳ Auto logout after inactivity */}
+        <AutoLogout />
 
         {/* 📦 Main Content */}
         <div className="pt-20 flex flex-col min-h-screen bg-[#1f2a44] text-[#e0e0e0]">


### PR DESCRIPTION
## Summary
- auto sign out users after 15 minutes of inactivity
- wire up the `AutoLogout` component in the main app

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68471b72f83c83308e830eb65272af91