### PR TITLE
Update timerRef initialization

### DIFF
--- a/components/AutoLogout.tsx
+++ b/components/AutoLogout.tsx
@@ -4,7 +4,7 @@ import { signOut } from "next-auth/react";
 const INACTIVITY_LIMIT = 15 * 60 * 1000; // 15 minutes in ms
 
 const AutoLogout = () => {
-  const timerRef = useRef<NodeJS.Timeout>();
+  const timerRef = useRef<NodeJS.Timeout | null>(null);
 
   useEffect(() => {
     const resetTimer = () => {


### PR DESCRIPTION
## Summary
- fix `useRef` initialization in `AutoLogout`

## Testing
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm run build` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68471ce79a808330862ddb3d10869317