### PR TITLE
Restrict auto logout to admins on admin pages

### DIFF
--- a/components/AutoLogout.tsx
+++ b/components/AutoLogout.tsx
@@ -1,12 +1,19 @@
 import { useEffect, useRef } from "react";
-import { signOut } from "next-auth/react";
+import { useSession, signOut } from "next-auth/react";
+import { useRouter } from "next/router";
 
 const INACTIVITY_LIMIT = 15 * 60 * 1000; // 15 minutes in ms
 
 const AutoLogout = () => {
+  const { data: session } = useSession();
+  const router = useRouter();
   const timerRef = useRef<NodeJS.Timeout | null>(null);
 
   useEffect(() => {
+    if (!session?.user?.isAdmin || !router.pathname.startsWith("/admin")) {
+      return;
+    }
+
     const resetTimer = () => {
       if (timerRef.current) clearTimeout(timerRef.current);
       timerRef.current = setTimeout(() => {
@@ -32,7 +39,7 @@ const AutoLogout = () => {
         window.removeEventListener(event, resetTimer)
       );
     };
-  }, []);
+  }, [session, router.pathname]);
 
   return null;
 };


### PR DESCRIPTION
## Summary
- only trigger auto logout when an admin is on admin pages

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847207326788330b4bddb77721aebe3