### PR TITLE
Restrict admin idle timer

### DIFF
--- a/components/AutoLogout.tsx
+++ b/components/AutoLogout.tsx
@@ -1,17 +1,56 @@
-import { useEffect, useRef } from "react";
-import { signOut } from "next-auth/react";
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  ReactNode,
+} from "react";
+import { useSession, signOut } from "next-auth/react";
+import { useRouter } from "next/router";
 
 const INACTIVITY_LIMIT = 15 * 60 * 1000; // 15 minutes in ms
 
-const AutoLogout = () => {
+interface IdleTimerContextValue {
+  remaining: number;
+}
+
+const IdleTimerContext = createContext<IdleTimerContextValue | undefined>(
+  undefined
+);
+
+export function useIdleTimer() {
+  const context = useContext(IdleTimerContext);
+  if (!context) {
+    throw new Error("useIdleTimer must be used within IdleTimerProvider");
+  }
+  return context;
+}
+
+export default function IdleTimerProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const { data: session } = useSession();
+  const router = useRouter();
   const timerRef = useRef<NodeJS.Timeout | null>(null);
+  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+  const [remaining, setRemaining] = useState(INACTIVITY_LIMIT);
 
   useEffect(() => {
     const resetTimer = () => {
       if (timerRef.current) clearTimeout(timerRef.current);
+      if (intervalRef.current) clearInterval(intervalRef.current);
+      setRemaining(INACTIVITY_LIMIT);
       timerRef.current = setTimeout(() => {
         signOut({ callbackUrl: "/" });
       }, INACTIVITY_LIMIT);
+      intervalRef.current = setInterval(() => {
+        setRemaining((prev) => (prev > 1000 ? prev - 1000 : 0));
+      }, 1000);
     };
 
     const events: (keyof WindowEventMap)[] = [
@@ -22,19 +61,26 @@ const AutoLogout = () => {
       "touchstart",
     ];
 
-    events.forEach((event) => window.addEventListener(event, resetTimer));
+    const isAdmin = session?.user?.isAdmin;
+    const onAdminPage = router.pathname.startsWith("/admin");
 
-    resetTimer();
+    if (isAdmin && onAdminPage) {
+      events.forEach((event) => window.addEventListener(event, resetTimer));
+      resetTimer();
+    }
 
     return () => {
       if (timerRef.current) clearTimeout(timerRef.current);
+      if (intervalRef.current) clearInterval(intervalRef.current);
       events.forEach((event) =>
         window.removeEventListener(event, resetTimer)
       );
     };
-  }, []);
+  }, [session, router.pathname]);
 
-  return null;
-};
-
-export default AutoLogout;
+  return (
+    <IdleTimerContext.Provider value={{ remaining }}>
+      {children}
+    </IdleTimerContext.Provider>
+  );
+}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -8,6 +8,7 @@ import { useRouter } from "next/router";
 import { useSession, signOut } from "next-auth/react";
 import { FiUser, FiShoppingCart, FiSearch, FiMenu, FiX } from "react-icons/fi";
 import { useCart } from "@/context/CartContext";
+import { useIdleTimer } from "@/components/AutoLogout";
 
 // 📝 Search results can be either site pages or products.
 // Update field mappings here if your schemas change.
@@ -31,8 +32,15 @@ const Navbar = () => {
   const router = useRouter();
   const pathname = router.pathname;
   const { data: session } = useSession();
+  const { remaining } = useIdleTimer();
   const { cartItems, increaseQty, decreaseQty, removeFromCart, addedItemName } =
     useCart();
+  const showCountdown =
+    session?.user?.isAdmin && pathname.startsWith("/admin");
+  const minutes = Math.floor(remaining / 60000);
+  const seconds = Math.floor((remaining % 60000) / 1000)
+    .toString()
+    .padStart(2, "0");
 
   const [scrolled, setScrolled] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
@@ -269,6 +277,11 @@ const Navbar = () => {
                 </span>
               )}
             </button>
+            {showCountdown && (
+              <span className="text-xs text-yellow-300">
+                {minutes}:{seconds}
+              </span>
+            )}
           </div>
         </div>
 
@@ -383,6 +396,12 @@ const Navbar = () => {
                 </span>
               )}
             </button>
+
+            {showCountdown && (
+              <span className="text-sm text-yellow-300">
+                {minutes}:{seconds}
+              </span>
+            )}
 
             {/* 🔍 Search Icon – toggles dropdown */}
             <button

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -8,7 +8,7 @@ import { SessionProvider } from "next-auth/react";
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
 import { CartProvider } from "@/context/CartContext";
-import AutoLogout from "@/components/AutoLogout";
+import IdleTimerProvider from "@/components/AutoLogout";
 
 // ⚡ Import the SpeedInsights component (no HOC wrapper needed)
 import { SpeedInsights } from "@vercel/speed-insights/next";
@@ -45,21 +45,21 @@ function App({ Component, pageProps: { session, ...pageProps } }: AppProps) {
   return (
     <SessionProvider session={session}>
       <CartProvider>
-        {/* 🌐 Navbar */}
-        <Navbar />
-        {/* ⏳ Auto logout after inactivity */}
-        <AutoLogout />
+        <IdleTimerProvider>
+          {/* 🌐 Navbar */}
+          <Navbar />
 
-        {/* 📦 Main Content */}
-        <div className="pt-20 flex flex-col min-h-screen bg-[#1f2a44] text-[#e0e0e0]">
-          <Component {...pageProps} />
-        </div>
+          {/* 📦 Main Content */}
+          <div className="pt-20 flex flex-col min-h-screen bg-[#1f2a44] text-[#e0e0e0]">
+            <Component {...pageProps} />
+          </div>
 
-        {/* 🦶 Footer */}
-        <Footer />
+          {/* 🦶 Footer */}
+          <Footer />
 
-        {/* ⚡ Insert SpeedInsights here */}
-        <SpeedInsights />
+          {/* ⚡ Insert SpeedInsights here */}
+          <SpeedInsights />
+        </IdleTimerProvider>
       </CartProvider>
     </SessionProvider>
   );


### PR DESCRIPTION
## Summary
- run auto logout timer only for admins on admin pages
- show countdown on navbar when timer active

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847207326788330b4bddb77721aebe3