### PR TITLE
Fix build error by restoring Next.js type definitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,4 +38,3 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
-next-env.d.ts

--- a/components/AutoLogout.tsx
+++ b/components/AutoLogout.tsx
@@ -1,4 +1,3 @@
-
 "use client";
 
 import {
@@ -10,42 +9,10 @@ import {
   ReactNode,
 } from "react";
 import { useSession, signOut } from "next-auth/react";
-
-
-
-const INACTIVITY_LIMIT = 15 * 60 * 1000; // 15 minutes in ms
-
-interface IdleTimerContextValue {
-  remaining: number;
-}
-
-const IdleTimerContext = createContext<IdleTimerContextValue | undefined>(
-  undefined
-);
-
-export function useIdleTimer() {
-  const context = useContext(IdleTimerContext);
-  if (!context) {
-    throw new Error("useIdleTimer must be used within IdleTimerProvider");
-  }
-  return context;
-}
-
-export default function IdleTimerProvider({
-  children,
-}: {
-  children: ReactNode;
-}) {
-  const { data: session } = useSession();
-
-import { useEffect, useRef } from "react";
-import { useSession, signOut } from "next-auth/react";
-
 import { useRouter } from "next/router";
 
 const INACTIVITY_LIMIT = 15 * 60 * 1000; // 15 minutes in ms
 
-
 interface IdleTimerContextValue {
   remaining: number;
 }
@@ -69,35 +36,27 @@ export default function IdleTimerProvider({
 }) {
   const { data: session } = useSession();
   const router = useRouter();
-
-const AutoLogout = () => {
-  const { data: session } = useSession();
-  const router = useRouter();
-
 
   const timerRef = useRef<NodeJS.Timeout | null>(null);
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
   const [remaining, setRemaining] = useState(INACTIVITY_LIMIT);
 
   useEffect(() => {
-
-
-
     if (!session) return;
 
-
-    if (!session?.user?.isAdmin || !router.pathname.startsWith("/admin")) {
+    if (!session.user?.isAdmin || !router.pathname.startsWith("/admin")) {
       return;
     }
-
 
     const resetTimer = () => {
       if (timerRef.current) clearTimeout(timerRef.current);
       if (intervalRef.current) clearInterval(intervalRef.current);
       setRemaining(INACTIVITY_LIMIT);
+
       timerRef.current = setTimeout(() => {
         signOut({ callbackUrl: "/" });
       }, INACTIVITY_LIMIT);
+
       intervalRef.current = setInterval(() => {
         setRemaining((prev) => (prev > 1000 ? prev - 1000 : 0));
       }, 1000);
@@ -117,24 +76,10 @@ const AutoLogout = () => {
     return () => {
       if (timerRef.current) clearTimeout(timerRef.current);
       if (intervalRef.current) clearInterval(intervalRef.current);
-      events.forEach((event) =>
-        window.removeEventListener(event, resetTimer)
-      );
+      events.forEach((event) => window.removeEventListener(event, resetTimer));
       setRemaining(INACTIVITY_LIMIT);
     };
-
   }, [session, router.pathname]);
-
-
-
-  }, [session]);
-
-  }, [session, router.pathname]);
-
-  return null;
-};
-
-
 
   return (
     <IdleTimerContext.Provider value={{ remaining }}>

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited


### PR DESCRIPTION
## Summary
- clean up `AutoLogout` implementation
- add missing `next-env.d.ts` so TypeScript can resolve Next.js modules
- stop ignoring `next-env.d.ts`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684727a6a2448330a22461870078a1a0