### PR TITLE
Add scroll to category navigation

### DIFF
--- a/pages/category/[category]/index.tsx
+++ b/pages/category/[category]/index.tsx
@@ -4,7 +4,8 @@ import { GetServerSideProps } from "next";
 import Head from "next/head";
 import Image from "next/image";
 import Link from "next/link";
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
+import { useRouter } from "next/router";
 import { useCart } from "@/context/CartContext";
 import { jewelryData } from "@/data/jewelryData"; // static data
 import Breadcrumbs from "@/components/Breadcrumbs";
@@ -43,6 +44,8 @@ export default function CategoryPage({
   const { addToCart } = useCart();
   const [visibleCount, setVisibleCount] = useState(8);
   const productsEndRef = useRef<HTMLDivElement>(null);
+  const titleRef = useRef<HTMLHeadingElement>(null);
+  const router = useRouter();
 
   // Normalize static data to Product[]
   const staticProducts: Product[] = jewelryData
@@ -101,6 +104,21 @@ export default function CategoryPage({
   const heroClass = categoryImagePosition[category.toLowerCase()];
   const heroSubtitle = categoryHeroSubtitles[category.toLowerCase()];
 
+  useEffect(() => {
+    if (!router.isReady) return;
+    if (router.query.scroll === "true") {
+      const header = document.querySelector("header");
+      const offset = (header as HTMLElement | null)?.clientHeight || 80;
+      if (titleRef.current) {
+        const top =
+          titleRef.current.getBoundingClientRect().top +
+          window.pageYOffset -
+          offset;
+        window.scrollTo({ top, behavior: "smooth" });
+      }
+    }
+  }, [router.isReady]);
+
   return (
     <div className="min-h-screen flex flex-col bg-[var(--bg-page)] text-[var(--foreground)]">
       {/* 🔖 Head Meta */}
@@ -141,7 +159,10 @@ export default function CategoryPage({
 
       {/* 💍 Product Grid Section */}
       <section className="py-20 px-4 sm:px-6 max-w-7xl mx-auto">
-        <h2 className="text-2xl sm:text-3xl font-semibold text-center mb-12">
+        <h2
+          ref={titleRef}
+          className="text-2xl sm:text-3xl font-semibold text-center mb-12"
+        >
           {prettyCategory} Pieces
         </h2>
         <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-6">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -100,7 +100,7 @@ export default function Home({ products }: HomeProps) {
               Discover handcrafted engagement rings, wedding bands, and fine
               jewelry.
             </p>
-            <Link href="/jewelry">
+            <Link href={{ pathname: "/jewelry", query: { scroll: "true" } }}>
               <button className="px-8 py-4 bg-[#e0e0e0] text-[#1f2a44] rounded-full hover:scale-105 transition">
                 Shop Now
               </button>
@@ -329,9 +329,13 @@ export default function Home({ products }: HomeProps) {
             ].map((gift, index) => (
               <Link
                 key={gift.name}
-                href={`/category/${gift.name
-                  .toLowerCase()
-                  .replace(/\s+/g, "-")}`}
+                href={{
+                  pathname: "/jewelry",
+                  query: {
+                    category: gift.name.toLowerCase().replace(/\s+/g, "-"),
+                    scroll: "true",
+                  },
+                }}
                 className="group relative rounded-xl overflow-hidden shadow-md hover:shadow-xl hover:scale-105 transition-transform duration-300"
               >
                 <div className="relative aspect-[4/3] w-full">


### PR DESCRIPTION
## Summary
- update Home page links so navigating to Jewelry page always passes `scroll=true`
- update Gift section links to filter the Jewelry page instead of direct category route
- implement scroll-to-title behavior on category pages when `scroll=true`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684823780494833085842af811195d64