### PR TITLE
Fix category scroll offset

### DIFF
--- a/pages/jewelry.tsx
+++ b/pages/jewelry.tsx
@@ -70,13 +70,7 @@ export default function JewelryPage({ products }: { products: ProductType[] }) {
 
     if (scroll === "true") {
       // Delay to ensure DOM is ready before scrolling
-
       setTimeout(scrollToTitle, 0);
-
-      setTimeout(() => {
-        titleRef.current?.scrollIntoView({ behavior: "smooth" });
-      }, 0);
-
     }
   }, [router.isReady]);
 


### PR DESCRIPTION
## Summary
- fix scroll to category title on jewelry page by removing extra `scrollIntoView` call

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68482b396cfc8330be925f9a5aa9deee