### PR TITLE
Add custom creation photo management

### DIFF
--- a/pages/admin/custom-photos.tsx
+++ b/pages/admin/custom-photos.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useState } from "react";
+import Head from "next/head";
+import Link from "next/link";
+import { getSession } from "next-auth/react";
+import Breadcrumbs from "@/components/Breadcrumbs";
+
+interface CustomPhoto {
+  _id: string;
+  imageUrl: string;
+  createdAt: string;
+}
+
+export async function getServerSideProps(context: any) {
+  const session = await getSession(context);
+  if (!session || !session.user?.isAdmin) {
+    return { redirect: { destination: "/", permanent: false } };
+  }
+  return { props: {} };
+}
+
+export default function AdminCustomPhotosPage() {
+  const [photos, setPhotos] = useState<CustomPhoto[]>([]);
+  const [imageFile, setImageFile] = useState<File | null>(null);
+  const [status, setStatus] = useState({ loading: false, error: "", success: "" });
+
+  useEffect(() => {
+    loadPhotos();
+  }, []);
+
+  const loadPhotos = async () => {
+    const res = await fetch("/api/custom-photos");
+    const data = await res.json();
+    setPhotos(data.photos || []);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!imageFile) return;
+    setStatus({ loading: true, error: "", success: "" });
+    try {
+      const formData = new FormData();
+      formData.append("image", imageFile);
+      const res = await fetch("/api/admin/custom-photos", {
+        method: "POST",
+        body: formData,
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.message);
+      setPhotos((p) => [data.photo, ...p]);
+      setImageFile(null);
+      setStatus({ loading: false, error: "", success: "Photo added" });
+    } catch (err: any) {
+      setStatus({ loading: false, error: err.message, success: "" });
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-[var(--bg-page)] text-[var(--foreground)] p-6">
+      <Head>
+        <title>Admin Custom Photos | Classy Diamonds</title>
+      </Head>
+      <div className="pl-2 pr-2 sm:pl-4 sm:pr-4 mb-6 -mt-2">
+        <Breadcrumbs />
+      </div>
+      <h1 className="text-3xl font-bold mb-6">🖼 Manage Custom Creations</h1>
+      <nav className="flex space-x-6 mb-8 border-b border-[var(--bg-nav)] pb-4 text-[var(--foreground)] text-sm font-semibold">
+        <Link href="/admin" className="hover:text-yellow-300">
+          📦 Orders
+        </Link>
+        <Link href="/admin/completed" className="hover:text-yellow-300">
+          ✅ Shipped
+        </Link>
+        <Link href="/admin/delivered" className="hover:text-yellow-300">
+          📬 Delivered
+        </Link>
+        <Link href="/admin/archived" className="hover:text-yellow-300">
+          🗂 Archived
+        </Link>
+        <Link href="/admin/products" className="hover:text-yellow-300">
+          🛠 Products
+        </Link>
+        <Link href="/admin/custom-photos" className="text-yellow-400">
+          🖼 Custom
+        </Link>
+        <Link href="/admin/logs" className="hover:text-yellow-300">
+          📝 Logs
+        </Link>
+      </nav>
+      {status.error && <p className="text-red-500">❌ {status.error}</p>}
+      {status.success && <p className="text-green-600">✅ {status.success}</p>}
+      <form onSubmit={handleSubmit} className="mb-8 space-y-4">
+        <label className="block">
+          <span>🖼 Image</span>
+          <input
+            type="file"
+            accept="image/*"
+            required
+            onChange={(e) => setImageFile(e.target.files?.[0] || null)}
+            className="mt-1 w-full"
+          />
+        </label>
+        <button
+          type="submit"
+          disabled={status.loading}
+          className="bg-blue-600 text-white rounded py-2 px-4 hover:bg-blue-700"
+        >
+          {status.loading ? "Saving..." : "Add Photo"}
+        </button>
+      </form>
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-4">
+        {photos.map((p) => (
+          <div key={p._id} className="relative w-full h-32 sm:h-36 md:h-40">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src={p.imageUrl} alt="Custom creation" className="object-cover rounded w-full h-full" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/pages/api/admin/custom-photos.ts
+++ b/pages/api/admin/custom-photos.ts
@@ -1,0 +1,97 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { v2 as cloudinary } from "cloudinary";
+import clientPromise from "@/lib/mongodb";
+import formidable from "formidable";
+
+export const config = { api: { bodyParser: false } };
+
+type CustomPhoto = {
+  _id: any;
+  imageUrl: string;
+  createdAt: Date;
+};
+
+type Data =
+  | { success: true; photos: CustomPhoto[] }
+  | { success: true; photo: CustomPhoto }
+  | { success: false; message: string };
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<Data>
+) {
+  if (
+    !process.env.CLOUDINARY_CLOUD_NAME ||
+    !process.env.CLOUDINARY_API_KEY ||
+    !process.env.CLOUDINARY_API_SECRET
+  ) {
+    return res
+      .status(500)
+      .json({ success: false, message: "Cloudinary configuration error" });
+  }
+
+  cloudinary.config({
+    cloud_name: process.env.CLOUDINARY_CLOUD_NAME,
+    api_key: process.env.CLOUDINARY_API_KEY,
+    api_secret: process.env.CLOUDINARY_API_SECRET,
+  });
+
+  const client = await clientPromise;
+  const db = client.db();
+  const collection = db.collection<CustomPhoto>("customPhotos");
+
+  if (req.method === "GET") {
+    const raw = await collection.find().sort({ createdAt: -1 }).toArray();
+    const photos: CustomPhoto[] = raw.map((doc: any) => ({
+      _id: doc._id,
+      imageUrl: doc.imageUrl,
+      createdAt: doc.createdAt,
+    }));
+    return res.status(200).json({ success: true, photos });
+  }
+
+  if (req.method !== "POST") {
+    res.setHeader("Allow", ["GET", "POST"]);
+    return res
+      .status(405)
+      .json({ success: false, message: `Method ${req.method} Not Allowed` });
+  }
+
+  try {
+    const form = new formidable.IncomingForm();
+    const { files } = await new Promise<any>((resolve, reject) => {
+      form.parse(req, (err, _fields, fls) =>
+        err ? reject(err) : resolve({ files: fls })
+      );
+    });
+
+    const rawFile = files.image;
+    const imageFile = Array.isArray(rawFile) ? rawFile[0] : rawFile;
+    if (!imageFile || typeof imageFile === "string") {
+      return res
+        .status(400)
+        .json({ success: false, message: "Image file missing" });
+    }
+
+    const uploadResult = await cloudinary.uploader.upload(imageFile.filepath, {
+      folder: "classy-diamonds/custom/original",
+      transformation: [{ quality: "auto" }, { fetch_format: "auto" }],
+      eager: [
+        {
+          folder: "classy-diamonds/custom/compressed",
+          quality: "auto",
+          fetch_format: "auto",
+        },
+      ],
+    });
+    const imageUrl = uploadResult.eager?.[0]?.secure_url || uploadResult.secure_url;
+
+    const doc = { imageUrl, createdAt: new Date() };
+    const result = await collection.insertOne(doc as any);
+    const photo: CustomPhoto = { _id: result.insertedId, ...doc };
+    return res.status(201).json({ success: true, photo });
+  } catch (err: any) {
+    console.error("Custom photo upload error", err);
+    return res.status(500).json({ success: false, message: err.message });
+  }
+}

--- a/pages/api/custom-photos.ts
+++ b/pages/api/custom-photos.ts
@@ -1,0 +1,21 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import clientPromise from "@/lib/mongodb";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== "GET") {
+    res.setHeader("Allow", ["GET"]);
+    return res.status(405).end(`Method ${req.method} Not Allowed`);
+  }
+
+  const client = await clientPromise;
+  const db = client.db();
+  const photos = await db
+    .collection("customPhotos")
+    .find()
+    .sort({ createdAt: -1 })
+    .toArray();
+  return res.status(200).json({ photos });
+}

--- a/pages/custom.tsx
+++ b/pages/custom.tsx
@@ -2,12 +2,25 @@
 
 import Head from "next/head";
 import Image from "next/image";
+import { useEffect, useState } from "react";
 
 import Breadcrumbs from "@/components/Breadcrumbs";
 
 import heroImage from "../public/hero-custom.jpg";
 
 export default function CustomPage() {
+  const [photos, setPhotos] = useState<{ _id: string; imageUrl: string }[]>([]);
+  const [selected, setSelected] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function load() {
+      const res = await fetch('/api/custom-photos');
+      const data = await res.json();
+      setPhotos(data.photos || []);
+    }
+    load();
+  }, []);
+
   return (
     <div className="min-h-screen flex flex-col bg-[var(--bg-page)] text-[var(--foreground)]">
       {/* 🌐 Head Metadata */}
@@ -45,6 +58,18 @@ export default function CustomPage() {
           </p>
         </div>
       </section>
+
+      {selected && (
+        <div
+          className="fixed inset-0 bg-black bg-opacity-80 flex items-center justify-center z-50"
+          onClick={() => setSelected(null)}
+        >
+          <div className="relative w-11/12 max-w-3xl" onClick={(e) => e.stopPropagation()}>
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src={selected} alt="Custom enlarged" className="w-full h-auto rounded" />
+          </div>
+        </div>
+      )}
 
       <div className="pl-4 pr-4 sm:pl-8 sm:pr-8 mt-6 mb-6">
         <Breadcrumbs />
@@ -86,17 +111,25 @@ export default function CustomPage() {
         <h2 className="text-2xl sm:text-3xl font-semibold text-center mb-12 sm:mb-16 text-[var(--foreground)]">
           Custom Creations
         </h2>
-        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6 sm:gap-8">
-          {[1, 2, 3].map((i) => (
-            <div
-              key={i}
-              className="group bg-[var(--bg-nav)] rounded-2xl shadow-md hover:shadow-2xl hover:scale-105 transition-all duration-300 flex items-center justify-center h-72 sm:h-80 cursor-pointer"
-            >
-              <p className="text-[#cfd2d6] group-hover:text-white transition-colors text-base sm:text-lg">
-                Custom Piece Coming Soon
-              </p>
-            </div>
-          ))}
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-4">
+          {photos.length === 0 ? (
+            <p>No custom creations yet.</p>
+          ) : (
+            photos.map((p) => (
+              <button
+                key={p._id}
+                onClick={() => setSelected(p.imageUrl)}
+                className="relative w-full h-32 sm:h-36 md:h-40"
+              >
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={p.imageUrl}
+                  alt="Custom creation"
+                  className="object-cover rounded w-full h-full"
+                />
+              </button>
+            ))
+          )}
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- add API for listing and uploading custom creation photos
- add admin page to upload custom photos
- display custom creation gallery on the Custom page with 6 images per row
- allow clicking gallery images to view them larger

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68484fc0bd488330b62d1a06560494a9