### PR TITLE
Remove global canonical link

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -14,11 +14,7 @@ export default function Document() {
           crossOrigin="anonymous"
         />
 
-        {/* 🧭 Canonical URL for SEO */}
-        <link
-          rel="canonical"
-          href="https://classydiamonds.vercel.app/contact"
-        />
+        {/* 🧭 Canonical links should be page specific and will be set in each page */}
 
         {/* ⏱️ Recommended if adding Google Fonts manually */}
         {/* <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=YourFont&display=swap" /> */}


### PR DESCRIPTION
## Summary
- adjust document head to remove the canonical link for the contact page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848516a5f108330bf76279cf68e2f10