### PR TITLE
Add custom photo admin preview and nav

### DIFF
--- a/pages/admin/archived.tsx
+++ b/pages/admin/archived.tsx
@@ -160,6 +160,9 @@ export default function ArchivedOrdersPage() {
         <Link href="/admin/products" className="hover:text-yellow-300">
           🛠 Products
         </Link>
+        <Link href="/admin/custom-photos" className="hover:text-yellow-300">
+          🖼 Custom
+        </Link>
         <Link href="/admin/logs" className="hover:text-yellow-300">
           📝 Logs
         </Link>

--- a/pages/admin/completed.tsx
+++ b/pages/admin/completed.tsx
@@ -235,6 +235,9 @@ export default function CompletedOrdersPage() {
         <Link href="/admin/products" className="hover:text-yellow-300">
           🛠 Products
         </Link>
+        <Link href="/admin/custom-photos" className="hover:text-yellow-300">
+          🖼 Custom
+        </Link>
         <Link href="/admin/logs" className="hover:text-yellow-300">
           📝 Logs
         </Link>

--- a/pages/admin/custom-photos.tsx
+++ b/pages/admin/custom-photos.tsx
@@ -21,11 +21,21 @@ export async function getServerSideProps(context: any) {
 export default function AdminCustomPhotosPage() {
   const [photos, setPhotos] = useState<CustomPhoto[]>([]);
   const [imageFile, setImageFile] = useState<File | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [status, setStatus] = useState({ loading: false, error: "", success: "" });
 
   useEffect(() => {
     loadPhotos();
   }, []);
+
+  useEffect(() => {
+    if (imageFile) {
+      const url = URL.createObjectURL(imageFile);
+      setPreviewUrl(url);
+      return () => URL.revokeObjectURL(url);
+    }
+    setPreviewUrl(null);
+  }, [imageFile]);
 
   const loadPhotos = async () => {
     const res = await fetch("/api/custom-photos");
@@ -98,6 +108,16 @@ export default function AdminCustomPhotosPage() {
             onChange={(e) => setImageFile(e.target.files?.[0] || null)}
             className="mt-1 w-full"
           />
+          {previewUrl && (
+            <div className="mt-2 w-32 h-32 relative">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={previewUrl}
+                alt="Preview"
+                className="object-cover rounded w-full h-full"
+              />
+            </div>
+          )}
         </label>
         <button
           type="submit"

--- a/pages/admin/delivered.tsx
+++ b/pages/admin/delivered.tsx
@@ -179,6 +179,9 @@ export default function DeliveredOrdersPage() {
         <Link href="/admin/products" className="hover:text-yellow-300">
           🛠 Products
         </Link>
+        <Link href="/admin/custom-photos" className="hover:text-yellow-300">
+          🖼 Custom
+        </Link>
         <Link href="/admin/logs" className="hover:text-yellow-300">
           📝 Logs
         </Link>

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -189,6 +189,9 @@ export default function AdminOrdersPage() {
         <Link href="/admin/products" className="hover:text-yellow-300">
           🛠 Products
         </Link>
+        <Link href="/admin/custom-photos" className="hover:text-yellow-300">
+          🖼 Custom
+        </Link>
         <Link href="/admin/logs" className="hover:text-yellow-300">
           📝 Logs
         </Link>

--- a/pages/admin/logs.tsx
+++ b/pages/admin/logs.tsx
@@ -157,6 +157,9 @@ export default function AdminLogsPage() {
         <Link href="/admin/products" className="hover:text-yellow-300">
           🛠 Products
         </Link>
+        <Link href="/admin/custom-photos" className="hover:text-yellow-300">
+          🖼 Custom
+        </Link>
         <Link href="/admin/logs" className="text-yellow-400">
           📝 Logs
         </Link>

--- a/pages/admin/products.tsx
+++ b/pages/admin/products.tsx
@@ -355,6 +355,9 @@ useEffect(() => {
         <Link href="/admin/products" className="text-yellow-400">
           🛠 Products
         </Link>
+        <Link href="/admin/custom-photos" className="hover:text-yellow-300">
+          🖼 Custom
+        </Link>
         <Link href="/admin/logs" className="hover:text-yellow-300">
           📝 Logs
         </Link>

--- a/pages/api/admin/custom-photos.ts
+++ b/pages/api/admin/custom-photos.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { v2 as cloudinary } from "cloudinary";
 import clientPromise from "@/lib/mongodb";
-import formidable from "formidable";
+import { IncomingForm } from "formidable";
 
 export const config = { api: { bodyParser: false } };
 
@@ -58,7 +58,7 @@ export default async function handler(
   }
 
   try {
-    const form = new formidable.IncomingForm();
+    const form = new IncomingForm();
     const { files } = await new Promise<any>((resolve, reject) => {
       form.parse(req, (err, _fields, fls) =>
         err ? reject(err) : resolve({ files: fls })


### PR DESCRIPTION
## Summary
- show preview when uploading custom photos
- fix IncomingForm import for custom photo uploads
- link `Custom` photo page in admin nav

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848529bcef88330b05baf8ded85f936