### PR TITLE
Add terms and privacy pages

### DIFF
--- a/pages/privacy.tsx
+++ b/pages/privacy.tsx
@@ -1,0 +1,45 @@
+import Head from "next/head";
+import Breadcrumbs from "@/components/Breadcrumbs";
+
+export default function PrivacyPage() {
+  return (
+    <div className="min-h-screen flex flex-col px-4 py-8">
+      <Head>
+        <title>Privacy Policy | Classy Diamonds</title>
+        <meta
+          name="description"
+          content="Learn how Classy Diamonds handles your personal information."
+        />
+      </Head>
+
+      <Breadcrumbs customLabels={{ privacy: "Privacy" }} />
+
+      <main className="prose prose-invert max-w-2xl mx-auto">
+        <h1>Privacy Policy</h1>
+        <p>
+          We respect your privacy and are committed to protecting your personal
+          information. This policy explains what we collect and how we use it.
+        </p>
+        <h2>Information We Collect</h2>
+        <p>
+          When you place an order or contact us, we may collect your name,
+          shipping address, email address, and phone number. We use this
+          information solely to fulfill your requests and to communicate with
+          you.
+        </p>
+        <h2>No Payment Details Collected</h2>
+        <p>
+          Classy Diamonds does not directly collect or store your credit card or
+          other payment details. All transactions are handled by secure third–
+          party processors such as Stripe. Please consult their privacy policies
+          for more information.
+        </p>
+        <h2>Contact</h2>
+        <p>
+          If you have questions about this policy, please reach out via our
+          <a href="/contact">contact page</a>.
+        </p>
+      </main>
+    </div>
+  );
+}

--- a/pages/terms.tsx
+++ b/pages/terms.tsx
@@ -1,0 +1,50 @@
+import Head from "next/head";
+import Breadcrumbs from "@/components/Breadcrumbs";
+
+export default function TermsPage() {
+  return (
+    <div className="min-h-screen flex flex-col px-4 py-8">
+      <Head>
+        <title>Terms of Service | Classy Diamonds</title>
+        <meta
+          name="description"
+          content="Review the terms of service for using Classy Diamonds."
+        />
+      </Head>
+
+      <Breadcrumbs customLabels={{ terms: "Terms" }} />
+
+      <main className="prose prose-invert max-w-2xl mx-auto">
+        <h1>Terms of Service</h1>
+        <p>
+          By accessing or using the Classy Diamonds website, you agree to the
+          following terms. These terms may be updated from time to time, and it
+          is your responsibility to review them periodically.
+        </p>
+        <h2>Use of Our Site</h2>
+        <p>
+          You may browse our catalog and place orders for products. All
+          purchases are subject to product availability. We reserve the right to
+          refuse or cancel any order.
+        </p>
+        <h2>Payments</h2>
+        <p>
+          We do not collect or store your payment information on this site. All
+          payments are processed securely through third–party providers such as
+          Stripe. Please refer to those providers for information about their
+          practices.
+        </p>
+        <h2>Limitation of Liability</h2>
+        <p>
+          Classy Diamonds is not liable for any indirect, incidental, or
+          consequential damages arising from your use of this site.
+        </p>
+        <h2>Contact Us</h2>
+        <p>
+          If you have any questions about these terms, please contact us through
+          our <a href="/contact">contact page</a>.
+        </p>
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `pages/terms.tsx` with basic Terms of Service details
- add `pages/privacy.tsx` with privacy information
- both pages note that payment information is handled by third-party processors

## Testing
- `npm run lint` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_e_68485ba0d20083308038a7f49da7e4bf