### PR TITLE
Fix gender variable redeclaration

### DIFF
--- a/pages/api/admin/products.ts
+++ b/pages/api/admin/products.ts
@@ -121,8 +121,6 @@ export default async function handler(
       ? (genderStr as "unisex" | "him" | "her")
       : "unisex";
 
-    const gender = getString(fields.gender, "unisex");
-
     const tagsRaw = fields.tags;
     const tags = Array.isArray(tagsRaw)
       ? tagsRaw.filter(Boolean)


### PR DESCRIPTION
## Summary
- remove duplicate gender variable that caused TypeScript compile errors

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm run build` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68486986bf448330ad239d5af14cef7b