### PR TITLE
Fix gender filter bug

### DIFF
--- a/pages/jewelry.tsx
+++ b/pages/jewelry.tsx
@@ -77,13 +77,19 @@ export default function JewelryPage({ products }: { products: ProductType[] }) {
 
     const { category, scroll } = router.query;
 
-    if (typeof category === "string" && category) {
+  if (typeof category === "string" && category) {
+    if (category === "for-him") {
+      setGenderFilter("him");
+      setActiveCategory("All");
+    } else if (category === "for-her") {
+      setGenderFilter("her");
+      setActiveCategory("All");
+    } else {
       setActiveCategory(category);
-      if (category === "for-him") setGenderFilter("him");
-      else if (category === "for-her") setGenderFilter("her");
-      else setGenderFilter(null);
-      resetCount();
+      setGenderFilter(null);
     }
+    resetCount();
+  }
 
     if (scroll === "true") {
       // Delay to ensure DOM is ready before scrolling


### PR DESCRIPTION
## Summary
- show all gender-specific products on `/jewelry` when coming from "For Him" or "For Her" links

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68486e27df8c83308a218c8b4335bf87