### PR TITLE
Fix headings for gendered pages and seed examples

### DIFF
--- a/data/jewelryData.ts
+++ b/data/jewelryData.ts
@@ -489,4 +489,42 @@ export const jewelryData = [
     slug: "blue-topaz-stud-earrings",
     category: "earrings",
   },
+  // 🎁 For Him
+  {
+    id: 701,
+    name: "Titanium Link Bracelet",
+    price: 900,
+    image: "/products/titanium-link-bracelet.jpg",
+    slug: "titanium-link-bracelet",
+    category: "bracelets",
+    gender: "him",
+  },
+  {
+    id: 702,
+    name: "Stainless Steel Cuff",
+    price: 750,
+    image: "/products/stainless-steel-cuff.jpg",
+    slug: "stainless-steel-cuff",
+    category: "bracelets",
+    gender: "him",
+  },
+  // 🎁 For Her
+  {
+    id: 703,
+    name: "Rose Gold Heart Necklace",
+    price: 1250,
+    image: "/products/rose-gold-heart-necklace.jpg",
+    slug: "rose-gold-heart-necklace",
+    category: "necklaces",
+    gender: "her",
+  },
+  {
+    id: 704,
+    name: "Dainty Diamond Studs",
+    price: 2100,
+    image: "/products/dainty-diamond-studs.jpg",
+    slug: "dainty-diamond-studs",
+    category: "earrings",
+    gender: "her",
+  },
 ];

--- a/pages/jewelry.tsx
+++ b/pages/jewelry.tsx
@@ -160,7 +160,17 @@ export default function JewelryPage({ products }: { products: ProductType[] }) {
           ref={titleRef}
           className="text-2xl sm:text-3xl font-semibold text-center mb-8"
         >
-          {activeCategory === "All" ? "Our Jewelry" : formatCategory(activeCategory)}
+          {`${
+            genderFilter === "him"
+              ? "For Him - "
+              : genderFilter === "her"
+              ? "For Her - "
+              : ""
+          }${
+            activeCategory === "All"
+              ? "Our Jewelry"
+              : formatCategory(activeCategory)
+          }`}
         </h2>
         <div className="flex flex-wrap justify-center gap-3 mt-4">
           {["All", ...categories].map((cat) => {


### PR DESCRIPTION
## Summary
- show gender prefix in jewelry page titles
- seed sample products marked for him and for her

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68486f9549d08330bcb043afbf34abf2