### PR TITLE
Improve gender sections

### DIFF
--- a/data/jewelryData.ts
+++ b/data/jewelryData.ts
@@ -123,6 +123,7 @@ export const jewelryData = [
     image: "/products/twist-rope-ring.jpg",
     slug: "twist-rope-wedding-ring",
     category: "wedding-bands",
+    gender: "him",
   },
   {
     id: 206,
@@ -131,6 +132,7 @@ export const jewelryData = [
     image: "/products/beveled-edge.jpg",
     slug: "beveled-edge-band",
     category: "wedding-bands",
+    gender: "him",
   },
   {
     id: 207,
@@ -343,6 +345,7 @@ export const jewelryData = [
     image: "/products/nameplate-necklace.jpg",
     slug: "gold-nameplate-necklace",
     category: "necklaces",
+    gender: "her",
   },
   {
     id: 503,
@@ -424,6 +427,7 @@ export const jewelryData = [
     image: "/products/gold-hoops.jpg",
     slug: "gold-hoop-earrings",
     category: "earrings",
+    gender: "her",
   },
   {
     id: 603,

--- a/pages/jewelry.tsx
+++ b/pages/jewelry.tsx
@@ -158,20 +158,24 @@ export default function JewelryPage({ products }: { products: ProductType[] }) {
       <section className="pt-16 pb-8 px-4 sm:px-6 max-w-7xl mx-auto">
         <h2
           ref={titleRef}
-          className="text-2xl sm:text-3xl font-semibold text-center mb-8"
+          className="text-2xl sm:text-3xl font-semibold text-center"
         >
-          {`${
-            genderFilter === "him"
-              ? "For Him - "
-              : genderFilter === "her"
-              ? "For Her - "
-              : ""
-          }${
-            activeCategory === "All"
-              ? "Our Jewelry"
-              : formatCategory(activeCategory)
-          }`}
+          {genderFilter === "him"
+            ? "For Him"
+            : genderFilter === "her"
+            ? "For Her"
+            : activeCategory === "All"
+            ? "Our Jewelry"
+            : formatCategory(activeCategory)}
         </h2>
+        {genderFilter && (
+          <p className="text-xl sm:text-2xl text-center mt-2 mb-6">
+            {activeCategory === "All"
+              ? "All Jewelry"
+              : formatCategory(activeCategory)}
+          </p>
+        )}
+        {!genderFilter && <div className="mb-8" />}
         <div className="flex flex-wrap justify-center gap-3 mt-4">
           {["All", ...categories].map((cat) => {
             const label = cat


### PR DESCRIPTION
## Summary
- show gender heading with category subtitle on jewelry page
- label a few products for him or for her

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684873580f9c8330af66472a99ebf6cf