### PR TITLE
Enable watch products in admin

### DIFF
--- a/data/productsData.ts
+++ b/data/productsData.ts
@@ -38,4 +38,23 @@ export const productsData = [
     description: "Elegant pearl drop earrings perfect for special occasions.",
     category: "earrings",
   },
+  {
+    id: 5,
+    slug: "classic-gold-watch",
+    name: "Classic Gold Watch",
+    price: 3200,
+    image: "/products/placeholder.jpg",
+    description: "A timeless gold watch with precision movement.",
+    category: "watches",
+  },
+  {
+    id: 6,
+    slug: "modern-chronograph",
+    name: "Modern Chronograph Watch",
+    price: 2800,
+    image: "/products/placeholder.jpg",
+    description:
+      "Sleek chronograph with leather band and stopwatch function.",
+    category: "watches",
+  },
 ];

--- a/pages/admin/products.tsx
+++ b/pages/admin/products.tsx
@@ -15,7 +15,8 @@ type Category =
   | "rings"
   | "bracelets"
   | "necklaces"
-  | "earrings";
+  | "earrings"
+  | "watches";
 
 const allCategories: Category[] = [
   "engagement",
@@ -24,6 +25,7 @@ const allCategories: Category[] = [
   "bracelets",
   "necklaces",
   "earrings",
+  "watches",
 ];
 
 
@@ -511,6 +513,7 @@ useEffect(() => {
                 "bracelets",
                 "necklaces",
                 "earrings",
+                "watches",
               ].map((cat) => (
                 <option key={cat} value={cat}>
                   {cat}
@@ -631,6 +634,7 @@ useEffect(() => {
               "bracelets",
               "necklaces",
               "earrings",
+              "watches",
             ].map((cat) => (
               <option key={cat} value={cat}>
                 {cat}


### PR DESCRIPTION
## Summary
- allow `watches` category in admin products page
- update category dropdowns to include Watches
- seed sample watch items

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684880ca44e08330819d44fd16d1ba02