### PR TITLE
Fix formidable import for product creation API

### DIFF
--- a/pages/api/admin/products.ts
+++ b/pages/api/admin/products.ts
@@ -4,7 +4,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { v2 as cloudinary } from "cloudinary";
 import slugify from "slugify";
 import clientPromise from "@/lib/mongodb";
-import formidable from "formidable";
+import { IncomingForm } from "formidable";
 
 // Disable Next.js built-in body parser to handle multipart/form-data
 export const config = { api: { bodyParser: false } };
@@ -92,7 +92,7 @@ export default async function handler(
 
   try {
     // 🛠️ Parse multipart/form-data
-    const form = new formidable.IncomingForm();
+    const form = new IncomingForm();
     const { fields, files } = await new Promise<any>((resolve, reject) => {
       form.parse(req, (err, flds, fls) =>
         err ? reject(err) : resolve({ fields: flds, files: fls })


### PR DESCRIPTION
## Summary
- fix `IncomingForm` usage in admin products endpoint

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684982a66c7083308a55c948420b6831