### PR TITLE
Fix hero scroll position

### DIFF
--- a/pages/jewelry.tsx
+++ b/pages/jewelry.tsx
@@ -54,10 +54,11 @@ export default function JewelryPage({ products }: { products: ProductType[] }) {
   const scrollToTitle = () => {
     const header = document.querySelector("header");
     const offset = (header as HTMLElement | null)?.clientHeight || 0;
+
     if (heroRef.current) {
       const bottom =
-        heroRef.current.getBoundingClientRect().bottom +
-        window.pageYOffset -
+        heroRef.current.offsetTop +
+        heroRef.current.offsetHeight -
         offset;
       window.scrollTo({ top: bottom, behavior: "smooth" });
     } else if (titleRef.current) {


### PR DESCRIPTION
## Summary
- adjust `scrollToTitle` to calculate hero bottom position consistently

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684987a1542c8330a305dc8755ccb0f4