### PR TITLE
Fix scrolling for gender links and unify product card sizes

### DIFF
--- a/pages/category/[category]/index.tsx
+++ b/pages/category/[category]/index.tsx
@@ -175,7 +175,7 @@ export default function CategoryPage({
                   href={`/category/${product.category}/${product.slug}`}
                   className="flex-1"
                 >
-                <div className="w-full h-44 sm:h-48 relative">
+                <div className="product-card-img">
                   <Image
                     src={product.image}
                     alt={product.name}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -332,7 +332,7 @@ export default function Home({ products }: HomeProps) {
                 href={{
                   pathname: "/jewelry",
                   query: {
-                    gender: gift.name.toLowerCase().split(" ")[1],
+                    category: gift.name.toLowerCase().replace(/\s+/g, "-"),
                     scroll: "true",
                   },
                 }}

--- a/pages/jewelry.tsx
+++ b/pages/jewelry.tsx
@@ -228,7 +228,7 @@ export default function JewelryPage({ products }: { products: ProductType[] }) {
               className="group bg-[var(--bg-nav)] rounded-2xl overflow-hidden shadow-lg hover:scale-105 transition flex flex-col h-full"
             >
               <Link href={`/category/${product.category}/${product.slug}`}>
-                <div className="w-full h-44 sm:h-48 relative">
+                <div className="product-card-img">
                   <Image
                     src={product.image}
                     alt={product.name}

--- a/pages/watches.tsx
+++ b/pages/watches.tsx
@@ -162,7 +162,7 @@ export default function WatchesPage({ products }: WatchesProps) {
               <Link
                 href={product.slug && product.slug !== "#" ? `/category/${product.category}/${product.slug}` : "#"}
               >
-                <div className="w-full h-44 sm:h-48 relative">
+                <div className="product-card-img">
                   <Image
                     src={product.image}
                     alt={product.name}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -104,3 +104,9 @@ input[type="reset"] {
 .hidden-scroll-snap-include {
   display: none;
 }
+
+@layer components {
+  .product-card-img {
+    @apply w-full h-44 sm:h-48 relative;
+  }
+}


### PR DESCRIPTION
## Summary
- link gender gifts to new `category` query so jewelry page scrolls
- standardize product card image dimensions with `.product-card-img`
- apply new class across product grid pages

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849a12085d88330bd665314a90dde98