### PR TITLE
Fix gift links and unify card sizes

### DIFF
--- a/pages/category/[category]/index.tsx
+++ b/pages/category/[category]/index.tsx
@@ -166,7 +166,7 @@ export default function CategoryPage({
         >
           {prettyCategory} Pieces
         </h2>
-        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-6">
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-6 auto-rows-fr">
           {allProducts.slice(0, visibleCount).map((product) => (
             <div key={product._id} className="group">
               <div className="bg-[var(--bg-nav)] rounded-2xl overflow-hidden shadow-lg hover:ring-2 hover:ring-[var(--foreground)] hover:scale-105 transition-transform duration-300 flex flex-col h-full">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -329,13 +329,7 @@ export default function Home({ products }: HomeProps) {
             ].map((gift, index) => (
               <Link
                 key={gift.name}
-                href={{
-                  pathname: "/jewelry",
-                  query: {
-                    category: gift.name.toLowerCase().replace(/\s+/g, "-"),
-                    scroll: "true",
-                  },
-                }}
+                href="/jewelry"
                 className="group relative rounded-xl overflow-hidden shadow-md hover:shadow-xl hover:scale-105 transition-transform duration-300"
               >
                 <div className="relative aspect-[4/3] w-full">

--- a/pages/jewelry.tsx
+++ b/pages/jewelry.tsx
@@ -221,13 +221,13 @@ export default function JewelryPage({ products }: { products: ProductType[] }) {
 
       {/* 📦 Products & Load More */}
       <section className="px-4 sm:px-6 max-w-7xl mx-auto mb-16">
-        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-6">
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-6 auto-rows-fr">
           {filteredProducts.slice(0, visibleCount).map((product) => (
             <div
               key={product.id}
               className="group bg-[var(--bg-nav)] rounded-2xl overflow-hidden shadow-lg hover:scale-105 transition flex flex-col h-full"
             >
-              <Link href={`/category/${product.category}/${product.slug}`}>
+              <Link href={`/category/${product.category}/${product.slug}`} className="flex-1 flex flex-col">
                 <div className="product-card-img">
                   <Image
                     src={product.image}

--- a/pages/watches.tsx
+++ b/pages/watches.tsx
@@ -153,7 +153,7 @@ export default function WatchesPage({ products }: WatchesProps) {
         <section className="pt-16 pb-8 px-4 sm:px-6 max-w-7xl mx-auto">
         <h1 className="text-3xl font-bold text-white text-center mb-6">Watches</h1>
 
-        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-6">
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-6 auto-rows-fr">
           {watchProducts.map((product) => (
             <div
               key={product.id}
@@ -161,6 +161,7 @@ export default function WatchesPage({ products }: WatchesProps) {
             >
               <Link
                 href={product.slug && product.slug !== "#" ? `/category/${product.category}/${product.slug}` : "#"}
+                className="flex-1 flex flex-col"
               >
                 <div className="product-card-img">
                   <Image


### PR DESCRIPTION
## Summary
- link gift items on the homepage directly to `/jewelry`
- ensure product grids use equal row heights
- allow product links to stretch to fill card space

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849ae9e32e48330a10298b70c8b659f