### PR TITLE
Fix gift links to open gender filters

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -329,7 +329,13 @@ export default function Home({ products }: HomeProps) {
             ].map((gift, index) => (
               <Link
                 key={gift.name}
-                href="/jewelry"
+                href={{
+                  pathname: "/jewelry",
+                  query: {
+                    category: gift.name.toLowerCase().replace(/\s+/g, "-"),
+                    scroll: "true",
+                  },
+                }}
                 className="group relative rounded-xl overflow-hidden shadow-md hover:shadow-xl hover:scale-105 transition-transform duration-300"
               >
                 <div className="relative aspect-[4/3] w-full">


### PR DESCRIPTION
## Summary
- link "For Him" and "For Her" gift cards on the homepage to the jewelry page with the correct gender filters

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849b85a73c88330b55f76b31991fe74