### PR TITLE
Fix gender filter links

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -329,7 +329,13 @@ export default function Home({ products }: HomeProps) {
             ].map((gift, index) => (
               <Link
                 key={gift.name}
-                href="/jewelry"
+                href={{
+                  pathname: "/jewelry",
+                  query: {
+                    gender: gift.name.toLowerCase().split(" ")[1],
+                    scroll: "true",
+                  },
+                }}
                 className="group relative rounded-xl overflow-hidden shadow-md hover:shadow-xl hover:scale-105 transition-transform duration-300"
               >
                 <div className="relative aspect-[4/3] w-full">

--- a/pages/jewelry.tsx
+++ b/pages/jewelry.tsx
@@ -83,11 +83,11 @@ export default function JewelryPage({ products }: { products: ProductType[] }) {
 
     const { category, gender, scroll } = router.query;
 
-    if (gender === "him" || category === "for-him") {
+    if (gender === "him") {
       setGenderFilter("him");
       setActiveCategory("All");
       resetCount();
-    } else if (gender === "her" || category === "for-her") {
+    } else if (gender === "her") {
       setGenderFilter("her");
       setActiveCategory("All");
       resetCount();
@@ -293,9 +293,10 @@ export default function JewelryPage({ products }: { products: ProductType[] }) {
 // Server-side data fetching
 export const getServerSideProps: GetServerSideProps = async ({ query }) => {
   const client = await clientPromise;
-  let genderQuery: "him" | "her" | undefined;
-  if (query.category === "for-him") genderQuery = "him";
-  if (query.category === "for-her") genderQuery = "her";
+  const genderQuery =
+    query.gender === "him" || query.gender === "her"
+      ? (query.gender as "him" | "her")
+      : undefined;
   const filter = genderQuery ? { gender: genderQuery } : {};
   const productsRaw = await client.db().collection("products").find(filter).toArray();
   const products: ProductType[] = productsRaw.map((p: any) => ({


### PR DESCRIPTION
## Summary
- link homepage "For Him" and "For Her" gifts to the jewelry page using `gender` query
- stop reading `category=for-him`/`for-her` queries on the jewelry page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849b85a73c88330b55f76b31991fe74