### PR TITLE
Fix gift links to include gender query

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -329,7 +329,13 @@ export default function Home({ products }: HomeProps) {
             ].map((gift, index) => (
               <Link
                 key={gift.name}
-                href="/jewelry"
+                href={{
+                  pathname: "/jewelry",
+                  query: {
+                    category: gift.name === "For Him" ? "for-him" : "for-her",
+                    scroll: "true",
+                  },
+                }}
                 className="group relative rounded-xl overflow-hidden shadow-md hover:shadow-xl hover:scale-105 transition-transform duration-300"
               >
                 <div className="relative aspect-[4/3] w-full">


### PR DESCRIPTION
## Summary
- update the "Gifts for Him & Her" links to behave like other category links

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849bd8eef008330bab6d2129158f40a