### PR TITLE
Fix gift section links

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -329,7 +329,13 @@ export default function Home({ products }: HomeProps) {
             ].map((gift, index) => (
               <Link
                 key={gift.name}
-                href="/jewelry"
+                href={{
+                  pathname: "/jewelry",
+                  query: {
+                    category: gift.name.toLowerCase().replace(/\s+/g, "-"),
+                    scroll: "true",
+                  },
+                }}
                 className="group relative rounded-xl overflow-hidden shadow-md hover:shadow-xl hover:scale-105 transition-transform duration-300"
               >
                 <div className="relative aspect-[4/3] w-full">


### PR DESCRIPTION
## Summary
- ensure "Gifts for Him & Her" links use the same filter query as other categories

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849c72e16c88330b61a1cadee5e50cb