### PR TITLE
Fix hero scroll and unify product card layout

### DIFF
--- a/pages/category/[category]/index.tsx
+++ b/pages/category/[category]/index.tsx
@@ -169,25 +169,25 @@ export default function CategoryPage({
         <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-6 auto-rows-fr">
           {allProducts.slice(0, visibleCount).map((product) => (
             <div key={product._id} className="group">
-              <div className="bg-[var(--bg-nav)] rounded-2xl overflow-hidden shadow-lg hover:ring-2 hover:ring-[var(--foreground)] hover:scale-105 transition-transform duration-300 flex flex-col h-full">
+              <div className="bg-[var(--bg-nav)] rounded-2xl overflow-hidden shadow-lg hover:ring-2 hover:ring-[var(--foreground)] hover:scale-105 transition-transform duration-300 flex flex-col h-full justify-between">
                 {/* 🔗 Product Link & Image */}
                 <Link
                   href={`/category/${product.category}/${product.slug}`}
-                  className="flex-1"
+                  className="flex-1 flex flex-col h-full"
                 >
                 <div className="product-card-img">
                   <Image
                     src={product.image}
                     alt={product.name}
                     fill
-                    className="object-cover group-hover:scale-110 transition"
+                    className="object-cover group-hover:scale-110 transition h-full w-full"
                   />
                 </div>
                 <div className="p-4 text-center flex-1 flex flex-col justify-between">
-                  <h3 className="font-semibold text-[var(--foreground)]">
+                  <h3 className="font-semibold text-[var(--foreground)] truncate text-sm">
                     {product.name}
                   </h3>
-                  <p className="text-[#cfd2d6]">
+                  <p className="text-[#cfd2d6] text-sm">
                     {product.salePrice ? (
                       <>
                         <span className="line-through mr-1">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -189,7 +189,7 @@ export default function Home({ products }: HomeProps) {
                 featured.map((item) => (
                   <div
                     key={item._id}
-                    className="flex-shrink-0 w-48 bg-[#25304f] rounded-2xl shadow-lg"
+                    className="flex-shrink-0 w-48 bg-[#25304f] rounded-2xl shadow-lg flex flex-col h-full justify-between"
                   >
                     <Link href={`/category/${item.category}/${item.slug}`}>
                       <Image
@@ -197,10 +197,10 @@ export default function Home({ products }: HomeProps) {
                         alt={item.name}
                         width={192}
                         height={192}
-                        className="rounded-t-2xl object-cover"
+                        className="rounded-t-2xl object-cover h-48 w-full"
                       />
                     </Link>
-                    <div className="p-4 text-center">
+                    <div className="p-4 text-center flex flex-col flex-grow justify-between">
                       <h3 className="text-sm font-semibold text-[#cfd2d6] truncate">
                         {item.name}
                       </h3>
@@ -254,23 +254,23 @@ export default function Home({ products }: HomeProps) {
               featured.map((item) => (
                 <div
                   key={item._id}
-                  className="group bg-[#25304f] rounded-2xl overflow-hidden shadow-lg hover:scale-105 transition"
+                  className="group bg-[#25304f] rounded-2xl overflow-hidden shadow-lg hover:scale-105 transition flex flex-col h-full justify-between"
                 >
                   <Link href={`/category/${item.category}/${item.slug}`}>
-                    <div className="relative w-full h-72">
+                    <div className="relative w-full h-64">
                       <Image
                         src={item.image}
                         alt={item.name}
                         fill
-                        className="object-cover group-hover:scale-110 transition"
+                        className="object-cover group-hover:scale-110 transition h-full w-full"
                       />
                     </div>
                   </Link>
-                  <div className="p-6 text-center">
-                    <h3 className="text-xl text-[#cfd2d6] mb-2 group-hover:text-white transition">
+                  <div className="p-6 text-center flex flex-col flex-grow justify-between">
+                    <h3 className="text-xl text-[#cfd2d6] mb-2 group-hover:text-white transition truncate text-sm">
                       {item.name}
                     </h3>
-                    <p className="text-gray-400 mb-4 group-hover:text-white transition">
+                    <p className="text-gray-400 mb-4 group-hover:text-white transition text-sm">
                       {item.salePrice ? (
                         <>
                           <span className="line-through mr-1">

--- a/pages/jewelry.tsx
+++ b/pages/jewelry.tsx
@@ -30,6 +30,7 @@ export default function JewelryPage({ products }: { products: ProductType[] }) {
   const [activeCategory, setActiveCategory] = useState<string>("All");
   const [genderFilter, setGenderFilter] = useState<"him" | "her" | null>(null);
   const titleRef = useRef<HTMLHeadingElement>(null);
+  const heroRef = useRef<HTMLElement>(null);
   const initialMount = useRef(true);
 
   const resetCount = () => setVisibleCount(8);
@@ -53,6 +54,7 @@ export default function JewelryPage({ products }: { products: ProductType[] }) {
       }
       resetCount();
       localStorage.removeItem("preselectedCategory");
+      setTimeout(scrollBelowHero, 0);
     }
   }, []);
 
@@ -67,16 +69,10 @@ export default function JewelryPage({ products }: { products: ProductType[] }) {
   const formatCategory = (cat: string) =>
     cat.replace(/-/g, " ").replace(/\b\w/g, (l) => l.toUpperCase());
 
-  const scrollToTitle = () => {
-    const header = document.querySelector("header");
-    const offset = (header as HTMLElement | null)?.clientHeight || 80;
-
-    if (titleRef.current) {
-      const top =
-        titleRef.current.getBoundingClientRect().top +
-        window.pageYOffset -
-        offset;
-      window.scrollTo({ top, behavior: "smooth" });
+  const scrollBelowHero = () => {
+    if (heroRef.current) {
+      const offset = heroRef.current.offsetTop + heroRef.current.offsetHeight;
+      window.scrollTo({ top: offset, behavior: "smooth" });
     }
   };
 
@@ -104,7 +100,7 @@ export default function JewelryPage({ products }: { products: ProductType[] }) {
 
     if (scroll === "true") {
       // Delay to ensure DOM is ready before scrolling
-      setTimeout(scrollToTitle, 0);
+      setTimeout(scrollBelowHero, 0);
     }
   }, [router.isReady]);
 
@@ -114,7 +110,7 @@ export default function JewelryPage({ products }: { products: ProductType[] }) {
       return;
     }
     resetCount();
-    scrollToTitle();
+    scrollBelowHero();
   }, [activeCategory, genderFilter]);
 
   const handleLoadMore = () => setVisibleCount((prev) => prev + 4);
@@ -141,6 +137,7 @@ export default function JewelryPage({ products }: { products: ProductType[] }) {
 
       {/* 🌟 Hero */}
       <section
+        ref={heroRef}
         className="-mt-20 relative w-full h-[80vh] flex items-center justify-center overflow-hidden"
       >
         <Image
@@ -229,22 +226,22 @@ export default function JewelryPage({ products }: { products: ProductType[] }) {
           {filteredProducts.slice(0, visibleCount).map((product) => (
             <div
               key={product.id}
-              className="group bg-[var(--bg-nav)] rounded-2xl overflow-hidden shadow-lg hover:scale-105 transition flex flex-col h-full"
+              className="group bg-[var(--bg-nav)] rounded-2xl overflow-hidden shadow-lg hover:scale-105 transition flex flex-col h-full justify-between"
             >
-              <Link href={`/category/${product.category}/${product.slug}`} className="flex-1 flex flex-col">
+              <Link href={`/category/${product.category}/${product.slug}`} className="flex-1 flex flex-col h-full">
                 <div className="product-card-img">
                   <Image
                     src={product.image}
                     alt={product.name}
                     fill
-                    className="object-cover group-hover:scale-110 transition"
+                    className="object-cover group-hover:scale-110 transition h-full w-full"
                   />
                 </div>
                 <div className="p-4 text-center flex-1 flex flex-col justify-between">
-                  <h3 className="font-semibold text-[var(--foreground)]">
+                  <h3 className="font-semibold text-[var(--foreground)] truncate text-sm">
                     {product.name}
                   </h3>
-                  <p className="text-[#cfd2d6]">
+                  <p className="text-[#cfd2d6] text-sm">
                     {product.salePrice ? (
                       <>
                         <span className="line-through mr-1">

--- a/pages/watches.tsx
+++ b/pages/watches.tsx
@@ -157,23 +157,23 @@ export default function WatchesPage({ products }: WatchesProps) {
           {watchProducts.map((product) => (
             <div
               key={product.id}
-              className="group bg-[var(--bg-nav)] rounded-2xl overflow-hidden shadow-lg hover:scale-105 transition flex flex-col h-full"
+              className="group bg-[var(--bg-nav)] rounded-2xl overflow-hidden shadow-lg hover:scale-105 transition flex flex-col h-full justify-between"
             >
               <Link
                 href={product.slug && product.slug !== "#" ? `/category/${product.category}/${product.slug}` : "#"}
-                className="flex-1 flex flex-col"
+                className="flex-1 flex flex-col h-full"
               >
                 <div className="product-card-img">
                   <Image
                     src={product.image}
                     alt={product.name}
                     fill
-                    className="object-cover group-hover:scale-110 transition"
+                    className="object-cover group-hover:scale-110 transition h-full w-full"
                   />
                 </div>
                 <div className="p-4 text-center flex-1 flex flex-col justify-between">
-                  <h3 className="font-semibold text-[var(--foreground)]">{product.name}</h3>
-                  <p className="text-[#cfd2d6]">${product.price.toLocaleString()}</p>
+                  <h3 className="font-semibold text-[var(--foreground)] truncate text-sm">{product.name}</h3>
+                  <p className="text-[#cfd2d6] text-sm">${product.price.toLocaleString()}</p>
                 </div>
               </Link>
               <button

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -107,6 +107,6 @@ input[type="reset"] {
 
 @layer components {
   .product-card-img {
-    @apply w-full h-44 sm:h-48 relative;
+    @apply relative w-full h-64;
   }
 }


### PR DESCRIPTION
## Summary
- ensure jewelry page scrolls below hero when filters load
- keep product card size consistent across all grids
- update featured cards styling
- tweak product-card-img utility

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849cc6962d08330a9a969af12fb26bc