### PR TITLE
Fix jewelry filter order

### DIFF
--- a/pages/jewelry.tsx
+++ b/pages/jewelry.tsx
@@ -59,8 +59,16 @@ export default function JewelryPage({ products }: { products: ProductType[] }) {
     }
   }, []);
 
-  const allCategories = Array.from(new Set(products.map((p) => p.category)));
-  const categoryFilters = [...allCategories, "for-him", "for-her"];
+  // Keep filters in a fixed order instead of relying on product data
+  const staticCategories = [
+    "rings",
+    "engagement",
+    "wedding-bands",
+    "bracelets",
+    "necklaces",
+    "earrings",
+  ];
+  const categoryFilters = [...staticCategories, "for-him", "for-her"];
 
   const scrollBelowHero = () => {
     const navHeight =


### PR DESCRIPTION
## Summary
- keep jewelry page filters in a fixed order

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*


------
https://chatgpt.com/codex/tasks/task_e_684b34370d0c8330ac14a1cbfd10812a