### PR TITLE
Add gender crumb to breadcrumbs

### DIFF
--- a/components/Breadcrumbs.tsx
+++ b/components/Breadcrumbs.tsx
@@ -16,6 +16,15 @@ export default function Breadcrumbs({
     .split("/")
     .filter((s) => Boolean(s) && s !== "category");
 
+  const genderParam =
+    router.query.gender === "him"
+      ? "for-him"
+      : router.query.gender === "her"
+      ? "for-her"
+      : router.query.category === "for-him" || router.query.category === "for-her"
+      ? (router.query.category as string)
+      : null;
+
   const isProductPage = router.pathname === "/category/[category]/[slug]";
 
   const buildHref = (index: number) => {
@@ -43,6 +52,17 @@ export default function Breadcrumbs({
             Home
           </Link>
         </li>
+        {genderParam && (
+          <li className="flex items-center">
+            <span className="mx-1">›</span>
+            <Link
+              href={`/jewelry?gender=${genderParam === "for-him" ? "him" : "her"}&scroll=true`}
+              className="hover:text-white text-white/70 capitalize"
+            >
+              {genderParam === "for-him" ? "For Him" : "For Her"}
+            </Link>
+          </li>
+        )}
         {segments.map((seg, i) => {
           const href = buildHref(i);
           const disableScroll = isProductPage && i === 0;

--- a/pages/jewelry.tsx
+++ b/pages/jewelry.tsx
@@ -236,7 +236,14 @@ export default function JewelryPage({ products }: { products: ProductType[] }) {
               className="group bg-[var(--bg-nav)] rounded-2xl overflow-hidden shadow-lg hover:scale-105 transition flex flex-col h-full justify-between"
             >
               <Link
-                href={`/category/${product.category}/${product.slug}`}
+                href={
+                  genderFilter
+                    ? {
+                        pathname: `/category/${product.category}/${product.slug}`,
+                        query: { gender: genderFilter },
+                      }
+                    : `/category/${product.category}/${product.slug}`
+                }
                 className="flex-1 flex flex-col h-full"
               >
                 <div className="relative w-full aspect-square">


### PR DESCRIPTION
## Summary
- include gender filters in breadcrumbs
- link product cards with active gender filter

## Testing
- `npm run lint` *(fails: requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_684c5cdfa3e88330882d8255e377188b