### PR TITLE
Enhance mobile filter layout

### DIFF
--- a/pages/jewelry.tsx
+++ b/pages/jewelry.tsx
@@ -182,7 +182,9 @@ export default function JewelryPage({ products }: { products: ProductType[] }) {
         )}
         {!genderFilter && <div className="mb-8" />}
 
-        <div className="flex flex-wrap justify-center gap-3 mt-4">
+        <div
+          className="flex flex-nowrap overflow-x-auto whitespace-nowrap no-scrollbar justify-start gap-3 mt-4 sm:flex-wrap sm:overflow-visible sm:whitespace-normal sm:justify-center"
+        >
           {["All", ...categoryFilters].map((cat) => {
             const label = cat
               .replace(/-/g, " ")


### PR DESCRIPTION
## Summary
- keep jewelry filters in a single row for mobile
- allow horizontal scrolling of filter buttons

## Testing
- `npm run lint` *(fails: interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_e_6854513142d083309b4f7553dd9b5e6d