### PR TITLE
Fix unmatched tag in jewelry page

### DIFF
--- a/pages/jewelry.tsx
+++ b/pages/jewelry.tsx
@@ -153,7 +153,6 @@ export default function JewelryPage({ products }: { products: ProductType[] }) {
             Discover timeless pieces crafted with passion.
           </p>
         </div>
-        </div>
       </section>
 
       {/* 🧭 Breadcrumbs */}


### PR DESCRIPTION
## Summary
- fix unclosed hero section tag in `pages/jewelry.tsx`

## Testing
- `npm run build` *(fails: TypeError: Cannot read properties of undefined (reading 'startsWith'))*

------
https://chatgpt.com/codex/tasks/task_e_685461340b148330bed95e9a29e6eec4