### PR TITLE
Enable pan-x for jewelry filters

### DIFF
--- a/pages/jewelry.tsx
+++ b/pages/jewelry.tsx
@@ -219,7 +219,7 @@ export default function JewelryPage({ products }: { products: ProductType[] }) {
                     setActiveCategory(cat);
                   }
                 }}
-                className={`flex-shrink-0 px-4 py-2 rounded-full font-semibold transition-transform hover:scale-105 ${
+                className={`touch-pan-x flex-shrink-0 px-4 py-2 rounded-full font-semibold transition-transform hover:scale-105 ${
                   active
                     ? "bg-[var(--foreground)] text-[var(--bg-nav)]"
                     : "bg-[var(--bg-nav)] text-[var(--foreground)] hover:bg-[#364763]"

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -48,6 +48,11 @@ header {
   scrollbar-width: none;
 }
 
+/* 🚼 Touch-action utilities */
+.touch-pan-x {
+  touch-action: pan-x;
+}
+
 /* 🖱️ Pointer cursor for all standard clickable elements */
 button,
 a,


### PR DESCRIPTION
## Summary
- add a touch-action helper for horizontal panning
- enable the helper on jewelry filter buttons

## Testing
- `npm run lint` *(fails: requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_685c1a745c688330aa13041dc177c9d0