### PR TITLE
Replace filter links with buttons

### DIFF
--- a/pages/jewelry.tsx
+++ b/pages/jewelry.tsx
@@ -204,28 +204,29 @@ export default function JewelryPage({ products }: { products: ProductType[] }) {
                 activeCategory === cat &&
                 !genderFilter);
 
-              const href =
-                cat === "for-him"
-                  ? { pathname: "/jewelry", query: { gender: "him" } }
-                  : cat === "for-her"
-                  ? { pathname: "/jewelry", query: { gender: "her" } }
-                  : cat === "All"
-                  ? "/jewelry"
-                  : { pathname: "/jewelry", query: { category: cat } };
-
               return (
-                <Link
+                <button
                   key={cat}
-                  href={href}
-                  scroll={false}
-                  className={`flex-shrink-0 px-4 py-2 rounded-full font-semibold transition-transform hover:scale-105 ${
+                  onClick={() => {
+                    if (cat === "for-him") {
+                      setGenderFilter("him");
+                      setActiveCategory("All");
+                    } else if (cat === "for-her") {
+                      setGenderFilter("her");
+                      setActiveCategory("All");
+                    } else {
+                      setGenderFilter(null);
+                      setActiveCategory(cat);
+                    }
+                  }}
+                  className={`touch-pan-x flex-shrink-0 px-4 py-2 rounded-full font-semibold transition-transform hover:scale-105 ${
                     active
                       ? "bg-[var(--foreground)] text-[var(--bg-nav)]"
                       : "bg-[var(--bg-nav)] text-[var(--foreground)] hover:bg-[#364763]"
                   }`}
                 >
                   {label}
-                </Link>
+                </button>
               );
             })}
         </div>


### PR DESCRIPTION
## Summary
- modify jewelry filter bar to use buttons instead of Links
- update onClick handlers to change filters and support scroll effect

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6862a6a374d48330a9c27944b858bdfd