### PR TITLE
Disable ESLint errors during build

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -6,6 +6,11 @@ const nextConfig = {
       "res.cloudinary.com", // allow Cloudinary-hosted images
     ],
   },
+  eslint: {
+    // Allow production builds to successfully complete even if
+    // there are ESLint errors in the project.
+    ignoreDuringBuilds: true,
+  },
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- allow production builds to ignore ESLint errors

This stops the build from failing due to lint errors in the codebase.

## Testing
- `npm install`
- `npm run build` *(fails: `Cannot read properties of undefined (reading 'startsWith')`)*

------
https://chatgpt.com/codex/tasks/task_e_6862b61223ec8330aa77faac65ec4c6e