### PR TITLE
Fix mobile filter bar layout

### DIFF
--- a/pages/jewelry.tsx
+++ b/pages/jewelry.tsx
@@ -182,7 +182,9 @@ export default function JewelryPage({ products }: { products: ProductType[] }) {
         )}
         {!genderFilter && <div className="mb-8" />}
 
-        <div className="flex flex-wrap justify-center gap-3 mt-4">
+        <div
+          className="flex flex-nowrap overflow-x-auto no-scrollbar whitespace-nowrap justify-start gap-3 px-4 mt-4 sm:flex-wrap sm:justify-center"
+        >
           {["All", ...categoryFilters].map((cat) => {
             const label = cat
               .replace(/-/g, " ")


### PR DESCRIPTION
## Summary
- keep jewelry page filters in a single scrolling row on mobile

## Testing
- `npx --no-install next lint` *(fails: Do not use an `<a>` element to navigate to `/contact/`. Use `<Link />` from `next/link` instead...)*

------
https://chatgpt.com/codex/tasks/task_e_6862b772245883309042f25d917224d0