### PR TITLE
Fix build by handling missing env vars

### DIFF
--- a/lib/mongodb.ts
+++ b/lib/mongodb.ts
@@ -2,7 +2,7 @@
 
 import { MongoClient } from "mongodb";
 
-const uri = process.env.MONGODB_URI!;
+const uri = process.env.MONGODB_URI;
 const options = {};
 
 let client;
@@ -13,11 +13,15 @@ declare global {
   var _mongoClientPromise: Promise<MongoClient> | undefined;
 }
 
-if (!global._mongoClientPromise) {
-  client = new MongoClient(uri, options);
-  global._mongoClientPromise = client.connect();
+if (uri) {
+  if (!global._mongoClientPromise) {
+    client = new MongoClient(uri, options);
+    global._mongoClientPromise = client.connect();
+  }
+  clientPromise = global._mongoClientPromise!;
+} else {
+  // When building without a MongoDB URI (e.g. CI build), return a dummy promise
+  clientPromise = Promise.resolve(null as any);
 }
-
-clientPromise = global._mongoClientPromise;
 
 export default clientPromise;

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,10 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  experimental: {
+    // Disable Critters to avoid missing module errors during build
+    optimizeCss: false,
+  },
   images: {
     domains: [
       "res.cloudinary.com", // allow Cloudinary-hosted images


### PR DESCRIPTION
## Summary
- disable `optimizeCss` experiment so `critters` isn't required
- safeguard MongoDB connection when `MONGODB_URI` isn't provided

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6862e59f346083308d2e8b2d7cf0d281