### PR TITLE
Add scroll offset for jewelry page filter navigation

### DIFF
--- a/pages/jewelry.tsx
+++ b/pages/jewelry.tsx
@@ -164,6 +164,7 @@ export default function JewelryPage({ products }: { products: ProductType[] }) {
       <section
         ref={headerRef}
         className="pt-16 pb-8 px-4 sm:px-6 max-w-7xl mx-auto"
+        style={{ scrollMarginTop: "40px" }}
       >
         <div className="text-center mb-4">
           <h2


### PR DESCRIPTION
## Summary
- add `scrollMarginTop` to the jewelry filter section so the heading isn't flush with the viewport after smooth scrolling

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68823cb1de008330be9cb1f1a1b592ae