### PR TITLE
Polish customer & admin pages

### DIFF
--- a/pages/admin/archived.tsx
+++ b/pages/admin/archived.tsx
@@ -141,7 +141,7 @@ export default function ArchivedOrdersPage() {
         <Breadcrumbs />
       </div>
 
-      <h1 className="text-3xl font-bold mb-6">🛠️ Admin Dashboard</h1>
+      <h1 className="text-3xl font-serif font-bold tracking-wide mb-6">🛠️ Admin Dashboard</h1>
 
       {/* 🔗 Admin Navigation Tabs */}
       <nav className="flex flex-wrap justify-center sm:justify-start gap-2 sm:space-x-6 mb-8 border-b border-[var(--bg-nav)] pb-4 text-[var(--foreground)] text-sm font-semibold">
@@ -193,7 +193,7 @@ export default function ArchivedOrdersPage() {
           {paginatedOrders.map((order) => (
             <div
               key={order._id}
-              className="bg-[var(--bg-nav)] p-6 rounded-xl shadow-md"
+              className="bg-[var(--bg-nav)] p-6 rounded-xl shadow-md hover:shadow-lg transition-shadow"
             >
               <h2 className="text-xl font-semibold mb-1">
                 {order.customerName} ({order.customerEmail})

--- a/pages/admin/completed.tsx
+++ b/pages/admin/completed.tsx
@@ -216,7 +216,7 @@ export default function CompletedOrdersPage() {
       </div>
 
       {/* 🛠️ Admin Dashboard Heading */}
-      <h1 className="text-3xl font-bold mb-6">🛠️ Admin Dashboard</h1>
+      <h1 className="text-3xl font-serif font-bold tracking-wide mb-6">🛠️ Admin Dashboard</h1>
 
       {/* 🔗 Admin Navigation Tabs */}
       <nav className="flex flex-wrap justify-center sm:justify-start gap-2 sm:space-x-6 mb-8 border-b border-[var(--bg-nav)] pb-4 text-[var(--foreground)] text-sm font-semibold">
@@ -289,7 +289,7 @@ export default function CompletedOrdersPage() {
             {paginatedOrders.map((order) => (
               <div
                 key={order._id}
-                className="bg-[var(--bg-nav)] rounded-xl p-6 shadow-md"
+                className="bg-[var(--bg-nav)] rounded-xl p-6 shadow-md hover:shadow-lg transition-shadow"
               >
                 <h2 className="text-xl font-semibold mb-1">
                   {order.customerName} ({order.customerEmail})

--- a/pages/admin/custom-photos.tsx
+++ b/pages/admin/custom-photos.tsx
@@ -72,7 +72,7 @@ export default function AdminCustomPhotosPage() {
       <div className="pl-2 pr-2 sm:pl-4 sm:pr-4 mb-6 -mt-2">
         <Breadcrumbs />
       </div>
-      <h1 className="text-3xl font-bold mb-6">🖼 Manage Custom Creations</h1>
+      <h1 className="text-3xl font-serif font-bold tracking-wide mb-6">🖼 Manage Custom Creations</h1>
       <nav className="flex flex-wrap justify-center sm:justify-start gap-2 sm:space-x-6 mb-8 border-b border-[var(--bg-nav)] pb-4 text-[var(--foreground)] text-sm font-semibold">
         <Link href="/admin" className="hover:text-yellow-300">
           📦 Orders

--- a/pages/admin/delivered.tsx
+++ b/pages/admin/delivered.tsx
@@ -160,7 +160,7 @@ export default function DeliveredOrdersPage() {
       </div>
 
       {/* 🛠️ Admin Dashboard Heading */}
-      <h1 className="text-3xl font-bold mb-6">🛠️ Admin Dashboard</h1>
+      <h1 className="text-3xl font-serif font-bold tracking-wide mb-6">🛠️ Admin Dashboard</h1>
 
       {/* 🔗 Admin Navigation Tabs */}
       <nav className="flex flex-wrap justify-center sm:justify-start gap-2 sm:space-x-6 mb-8 border-b border-[var(--bg-nav)] pb-4 text-[var(--foreground)] text-sm font-semibold">
@@ -233,7 +233,7 @@ export default function DeliveredOrdersPage() {
             {paginatedOrders.map((order) => (
               <div
                 key={order._id}
-                className="bg-[var(--bg-nav)] rounded-xl p-6 shadow-md"
+                className="bg-[var(--bg-nav)] rounded-xl p-6 shadow-md hover:shadow-lg transition-shadow"
               >
                 <h2 className="text-xl font-semibold mb-1">
                   {order.customerName} ({order.customerEmail})

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -171,7 +171,7 @@ export default function AdminOrdersPage() {
         <Breadcrumbs />
       </div>
 
-      <h1 className="text-3xl font-bold mb-6">🛠️ Admin Dashboard</h1>
+      <h1 className="text-3xl font-serif font-bold tracking-wide mb-6">🛠️ Admin Dashboard</h1>
 
       <nav className="flex flex-wrap justify-center sm:justify-start gap-2 sm:space-x-6 mb-8 border-b border-[var(--bg-nav)] pb-4 text-[var(--foreground)] text-sm font-semibold">
         <Link href="/admin" className="text-yellow-400">
@@ -241,7 +241,7 @@ export default function AdminOrdersPage() {
             {paginatedOrders.map((order) => (
               <div
                 key={order._id}
-                className="bg-[var(--bg-nav)] p-6 rounded-xl shadow-md"
+                className="bg-[var(--bg-nav)] p-6 rounded-xl shadow-md hover:shadow-lg transition-shadow"
               >
                 <h2 className="text-xl font-semibold mb-1">
                   {order.customerName} ({order.customerEmail})

--- a/pages/admin/logs.tsx
+++ b/pages/admin/logs.tsx
@@ -138,7 +138,7 @@ export default function AdminLogsPage() {
         <Breadcrumbs />
       </div>
 
-      <h1 className="text-3xl font-bold mb-6">🛠️ Admin Dashboard</h1>
+      <h1 className="text-3xl font-serif font-bold tracking-wide mb-6">🛠️ Admin Dashboard</h1>
 
       {/* 🔗 Admin Navigation Tabs */}
       <nav className="flex flex-wrap justify-center sm:justify-start gap-2 sm:space-x-6 mb-8 border-b border-[var(--bg-nav)] pb-4 text-[var(--foreground)] text-sm font-semibold">

--- a/pages/admin/products.tsx
+++ b/pages/admin/products.tsx
@@ -406,7 +406,7 @@ useEffect(() => {
         <Breadcrumbs />
       </div>
 
-      <h1 className="text-3xl font-bold mb-6">🛠️ Admin Dashboard</h1>
+      <h1 className="text-3xl font-serif font-bold tracking-wide mb-6">🛠️ Admin Dashboard</h1>
 
       <nav className="flex flex-wrap justify-center sm:justify-start gap-2 sm:space-x-6 mb-8 border-b border-[var(--bg-nav)] pb-4 text-[var(--foreground)] text-sm font-semibold">
         <Link href="/admin" className="hover:text-yellow-300">

--- a/pages/contact.tsx
+++ b/pages/contact.tsx
@@ -182,7 +182,7 @@ export default function ContactPage() {
             <div className="absolute inset-0 bg-black opacity-50 pointer-events-none" />
           </div>
           <div className="relative z-10 px-4">
-            <h1 className="text-3xl sm:text-4xl font-serif font-semibold mb-6 text-[var(--foreground)]">
+            <h1 className="text-3xl sm:text-4xl font-serif font-semibold tracking-wider leading-snug mb-6 text-[var(--foreground)]">
               Contact Classy Diamonds
             </h1>
             <p className="text-[var(--foreground)] max-w-2xl mx-auto text-base sm:text-lg">
@@ -208,7 +208,7 @@ export default function ContactPage() {
               />
             </div>
             <div className="text-center md:text-left">
-              <h2 className="text-2xl sm:text-3xl font-semibold mb-6 sm:mb-8">
+              <h2 className="text-2xl sm:text-3xl font-serif font-semibold tracking-wide leading-snug mb-6 sm:mb-8">
                 About Us
               </h2>
               <p className="text-base sm:text-lg text-[#cfd2d6] leading-relaxed">

--- a/pages/custom.tsx
+++ b/pages/custom.tsx
@@ -49,7 +49,7 @@ export default function CustomPage() {
         </div>
 
         <div className="relative z-10 px-4">
-          <h1 className="text-3xl sm:text-4xl md:text-5xl font-bold mb-6 text-[var(--foreground)]">
+          <h1 className="text-3xl sm:text-4xl md:text-5xl font-serif font-bold tracking-wider leading-snug mb-6 text-[var(--foreground)]">
             Create Your Dream Piece
           </h1>
           <p className="text-base sm:text-lg md:text-xl max-w-2xl mx-auto text-[var(--foreground)]">
@@ -77,7 +77,7 @@ export default function CustomPage() {
 
       {/* 🧭 How It Works Section */}
       <section className="px-4 sm:px-6 py-16 sm:py-20 max-w-7xl mx-auto">
-        <h2 className="text-2xl sm:text-3xl font-semibold text-center mb-12 sm:mb-16 text-[var(--foreground)]">
+        <h2 className="text-2xl sm:text-3xl font-serif font-semibold tracking-wide leading-snug text-center mb-12 sm:mb-16 text-[var(--foreground)]">
           How It Works
         </h2>
         <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-6 sm:gap-8">
@@ -108,7 +108,7 @@ export default function CustomPage() {
 
       {/* 💎 Custom Creations Grid */}
       <section className="px-4 sm:px-6 py-16 sm:py-20 max-w-7xl mx-auto">
-        <h2 className="text-2xl sm:text-3xl font-semibold text-center mb-12 sm:mb-16 text-[var(--foreground)]">
+        <h2 className="text-2xl sm:text-3xl font-serif font-semibold tracking-wide leading-snug text-center mb-12 sm:mb-16 text-[var(--foreground)]">
           Custom Creations
         </h2>
         <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-4">
@@ -136,7 +136,7 @@ export default function CustomPage() {
       {/* 📣 Call to Action */}
       <section className="py-16 sm:py-20 px-4 sm:px-6">
         <div className="max-w-4xl mx-auto text-center">
-          <h2 className="text-2xl sm:text-3xl font-semibold mb-6 sm:mb-8 text-[var(--foreground)]">
+          <h2 className="text-2xl sm:text-3xl font-serif font-semibold tracking-wide leading-snug mb-6 sm:mb-8 text-[var(--foreground)]">
             Ready to Create Your Piece?
           </h2>
           <p className="text-base sm:text-lg mb-6 sm:mb-8 leading-relaxed text-[#cfd2d6]">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -131,7 +131,7 @@ export default function Home({ products }: HomeProps) {
           />
           <div className="absolute inset-0 bg-black/50" />
           <div className="relative z-10 text-center px-4">
-            <h1 className="text-3xl sm:text-4xl md:text-6xl font-serif font-bold tracking-wide leading-tight text-[#e0e0e0] mb-6">
+            <h1 className="text-3xl sm:text-4xl md:text-6xl font-serif font-bold tracking-wider leading-snug text-[#e0e0e0] mb-6">
               Timeless Elegance
             </h1>
             <p className="text-base sm:text-lg md:text-xl text-[#e0e0e0] mb-8 max-w-2xl mx-auto leading-relaxed">
@@ -377,7 +377,7 @@ export default function Home({ products }: HomeProps) {
         {/* 🛠️ About Section */}
         <section className="py-16 sm:py-20 px-4 sm:px-6 --bg-page">
           <div className="max-w-4xl mx-auto text-center">
-            <h2 className="text-2xl sm:text-3xl font-serif font-semibold mb-6 sm:mb-8">
+            <h2 className="text-2xl sm:text-3xl font-serif font-semibold mb-6 sm:mb-8 tracking-wide">
               Craftsmanship You Can Trust
             </h2>
             <p className="text-base sm:text-lg text-[#cfd2d6] leading-relaxed">
@@ -393,7 +393,7 @@ export default function Home({ products }: HomeProps) {
         {/* 💎 Why Choose Us Section */}
         <section className="py-16 sm:py-20 px-4 sm:px-6 --bg-page">
           <div className="max-w-4xl mx-auto text-center">
-            <h2 className="text-3xl sm:text-4xl font-serif font-bold mb-8 sm:mb-10">
+            <h2 className="text-3xl sm:text-4xl font-serif font-bold mb-8 sm:mb-10 tracking-wide">
               Why Choose Classy Diamonds?
             </h2>
             <p className="text-base sm:text-lg text-[#cfd2d6] leading-relaxed">
@@ -409,7 +409,7 @@ export default function Home({ products }: HomeProps) {
         {/* ✍️ Custom Jewelry CTA */}
         <section className="--bg-page py-16 sm:py-20 px-4 sm:px-6">
           <div className="max-w-5xl mx-auto text-center">
-            <h2 className="text-3xl sm:text-4xl font-serif font-bold mb-8">
+            <h2 className="text-3xl sm:text-4xl font-serif font-bold mb-8 tracking-wide">
               {" "}
               Bring Your Vision to Life
             </h2>

--- a/pages/jewelry.tsx
+++ b/pages/jewelry.tsx
@@ -146,7 +146,7 @@ export default function JewelryPage({ products }: { products: ProductType[] }) {
         />
         <div className="absolute inset-0 bg-black/50 pointer-events-none" />
         <div className="relative z-10 text-center px-4">
-          <h1 className="text-3xl md:text-6xl font-serif font-bold tracking-wide leading-tight mb-4 text-[var(--foreground)]">
+          <h1 className="text-3xl md:text-6xl font-serif font-bold tracking-wider leading-snug mb-4 text-[var(--foreground)]">
             Jewelry Collection
           </h1>
           <p className="text-base md:text-xl max-w-2xl mx-auto text-[var(--foreground)] leading-relaxed tracking-wide">
@@ -169,7 +169,7 @@ export default function JewelryPage({ products }: { products: ProductType[] }) {
         <div className="text-center mb-6">
           <h2
             ref={titleRef}
-            className="text-2xl sm:text-3xl font-serif font-semibold tracking-wide"
+            className="text-2xl sm:text-3xl font-serif font-semibold tracking-wider leading-snug"
           >
           {genderFilter === "him"
             ? "For Him"
@@ -180,7 +180,7 @@ export default function JewelryPage({ products }: { products: ProductType[] }) {
             : formatCategory(activeCategory)}
           </h2>
           {genderFilter && (
-            <p className="text-xl sm:text-2xl mt-2 font-serif tracking-wide">
+            <p className="text-xl sm:text-2xl mt-2 font-serif tracking-wider leading-snug">
             {activeCategory === "All"
               ? "All Jewelry"
               : formatCategory(activeCategory)}
@@ -243,7 +243,7 @@ export default function JewelryPage({ products }: { products: ProductType[] }) {
           {filteredProducts.slice(0, visibleCount).map((product) => (
             <div
               key={product.id}
-              className="group bg-[var(--bg-nav)] rounded-2xl overflow-hidden shadow-lg hover:shadow-xl hover:scale-105 transition-transform duration-300 flex flex-col h-full justify-between"
+              className="group bg-[var(--bg-nav)] rounded-2xl overflow-hidden shadow-md hover:shadow-2xl hover:scale-105 transition-transform duration-300 flex flex-col h-full justify-between"
             >
               <Link
                 href={

--- a/pages/watches.tsx
+++ b/pages/watches.tsx
@@ -138,7 +138,7 @@ export default function WatchesPage({ products }: WatchesProps) {
         <Image src="/hero-jewelry.jpg" alt="Watch Hero" fill className="object-cover" />
         <div className="absolute inset-0 bg-black/50 pointer-events-none" />
         <div className="relative z-10 text-center px-4">
-          <h1 className="text-3xl md:text-6xl font-serif font-bold tracking-wide leading-tight mb-4 text-[var(--foreground)]">Watch Collection</h1>
+          <h1 className="text-3xl md:text-6xl font-serif font-bold tracking-wider leading-snug mb-4 text-[var(--foreground)]">Watch Collection</h1>
           <p className="text-base md:text-xl max-w-2xl mx-auto text-[var(--foreground)] leading-relaxed tracking-wide">
             Explore precision-crafted timepieces.
           </p>
@@ -157,7 +157,7 @@ export default function WatchesPage({ products }: WatchesProps) {
           {watchProducts.map((product) => (
             <div
               key={product.id}
-              className="group bg-[var(--bg-nav)] rounded-2xl overflow-hidden shadow-lg hover:shadow-xl hover:ring-2 hover:ring-[var(--foreground)] hover:scale-105 transition-transform duration-300 flex flex-col h-full justify-between"
+              className="group bg-[var(--bg-nav)] rounded-2xl overflow-hidden shadow-md hover:shadow-2xl hover:ring-2 hover:ring-[var(--foreground)] hover:scale-105 transition-transform duration-300 flex flex-col h-full justify-between"
             >
               <Link
                 href={product.slug && product.slug !== "#" ? `/category/${product.category}/${product.slug}` : "#"}


### PR DESCRIPTION
## Summary
- refine typography across home, product, custom, and contact pages
- add soft shadows and transitions for product/admin cards
- tweak admin dashboard headings for consistent styling

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882611c86d88330aced7e9fe0cb7ce1