### PR TITLE
Add shipping details to orders

### DIFF
--- a/pages/api/webhook.ts
+++ b/pages/api/webhook.ts
@@ -172,6 +172,17 @@ export default async function handler(
             shippingName,
             shippingAddress,
             shipping: shippingAddressObject,
+            // ➕ Persist shipping details from Stripe
+            shipping_name: shippingName,
+            shipping_address: {
+              street: shipStreet,
+              line2: shipLine2,
+              city: shipCity,
+              state: shipState,
+              zip: shipZip,
+              country: shipCountry,
+            },
+            shipping_address_string: shippingAddress,
             items,
             amount: amountTotal,
             currency: session.currency || "usd",


### PR DESCRIPTION
## Summary
- capture `shipping_details` from Stripe Checkout sessions
- insert structured shipping info into MongoDB orders

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68828ae58f24833088f83154bd2e9726