### PR TITLE
Save shipping address from Stripe & tweak admin UI

### DIFF
--- a/pages/admin/completed.tsx
+++ b/pages/admin/completed.tsx
@@ -289,7 +289,7 @@ export default function CompletedOrdersPage() {
             {paginatedOrders.map((order) => (
               <div
                 key={order._id}
-                className="bg-[var(--bg-nav)] rounded-xl p-6 shadow-md hover:shadow-xl hover:scale-105 transition-transform duration-300"
+                className="bg-[var(--bg-nav)] rounded-xl p-6 shadow-md transition-all duration-200"
               >
                 <h2 className="text-xl font-semibold mb-1">
                   {order.customerName} ({order.customerEmail})

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -241,7 +241,7 @@ export default function AdminOrdersPage() {
             {paginatedOrders.map((order) => (
               <div
                 key={order._id}
-                className="bg-[var(--bg-nav)] p-6 rounded-xl shadow-md hover:shadow-xl hover:scale-105 transition-transform duration-300"
+                className="bg-[var(--bg-nav)] p-6 rounded-xl shadow-md transition-all duration-200"
               >
                 <h2 className="text-xl font-semibold mb-1">
                   {order.customerName} ({order.customerEmail})

--- a/pages/api/webhook.ts
+++ b/pages/api/webhook.ts
@@ -46,7 +46,7 @@ export default async function handler(
 
     // 👀 Handle only the “checkout.session.completed” event
     if (event.type === "checkout.session.completed") {
-      const session = event.data.object as Stripe.Checkout.Session;
+      const session = event.data.object as any; // allow access to shipping_details
 
       // 🔍 Pull customer details from session
       const customerName = session.customer_details?.name || "Customer";
@@ -80,46 +80,26 @@ export default async function handler(
         country,
       };
 
-      // 📮 Extract shipping details directly from the session when present
-      const shippingDetails = (session as any).shipping_details as
-        | {
-            name?: string;
-            address?: Stripe.Address;
-          }
-        | null;
+      // 📮 Extract shipping details from the session
+      const shippingDetails = session.shipping_details;
+      const shippingName = shippingDetails?.name || "";
+      const shippingAddr = shippingDetails?.address || {};
+      const shipStreet = (shippingAddr as any).line1 || "";
+      const shipLine2 = (shippingAddr as any).line2 || "";
+      const shipCity = (shippingAddr as any).city || "";
+      const shipState = (shippingAddr as any).state || "";
+      const shipZip = (shippingAddr as any).postal_code || "";
+      const shipCountry = (shippingAddr as any).country || "";
 
-      let shippingName: string | undefined;
-      let shippingAddress: string | undefined;
-      let shippingAddressObject:
-        | {
-            street: string;
-            line2: string;
-            city: string;
-            state: string;
-            zip: string;
-            country: string;
-          }
-        | undefined;
-
-      if (shippingDetails) {
-        const line1 = shippingDetails.address?.line1 || "";
-        const line2 = shippingDetails.address?.line2 || "";
-        const city = shippingDetails.address?.city || "";
-        const state = shippingDetails.address?.state || "";
-        const zip = shippingDetails.address?.postal_code || "";
-        const country = shippingDetails.address?.country || "";
-
-        shippingName = shippingDetails.name;
-        shippingAddress = `${line1}${line2 ? ", " + line2 : ""}, ${city}, ${state} ${zip}, ${country}`;
-        shippingAddressObject = {
-          street: line1,
-          line2,
-          city,
-          state,
-          zip,
-          country,
-        };
-      }
+      const shippingAddress = `${shipStreet}${shipLine2 ? `, ${shipLine2}` : ""}, ${shipCity}, ${shipState} ${shipZip}, ${shipCountry}`;
+      const shippingAddressObject = {
+        street: shipStreet,
+        line2: shipLine2,
+        city: shipCity,
+        state: shipState,
+        zip: shipZip,
+        country: shipCountry,
+      };
 
       // 💲 Calculate total amount in dollars
       const amountTotal = (session.amount_total || 0) / 100;
@@ -194,23 +174,10 @@ export default async function handler(
             shipped: false,
             delivered: false,
             archived: false,
+            shipping_name: shippingName,
+            shipping_address: shippingAddressObject,
+            shipping_address_string: shippingAddress,
           };
-
-          if (shippingDetails) {
-            orderDoc.shippingName = shippingName;
-            orderDoc.shippingAddress = shippingAddress;
-            orderDoc.shipping = shippingAddressObject;
-            orderDoc.shipping_name = shippingDetails.name;
-            orderDoc.shipping_address = {
-              street: shippingAddressObject!.street,
-              line2: shippingAddressObject!.line2,
-              city: shippingAddressObject!.city,
-              state: shippingAddressObject!.state,
-              zip: shippingAddressObject!.zip,
-              country: shippingAddressObject!.country,
-            };
-            orderDoc.shipping_address_string = shippingAddress;
-          }
 
           await ordersCollection.insertOne(orderDoc);
 


### PR DESCRIPTION
## Summary
- capture shipping name/address from Stripe session in webhook
- simplify order container styles in admin dashboard (orders & shipped pages)
- fix TS type issue by casting session as any for shipping_details

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68828f2e4fd08330971b2e97b99b9f6e