### PR TITLE
Fix shipping info & discounted pricing

### DIFF
--- a/pages/account/orders.tsx
+++ b/pages/account/orders.tsx
@@ -183,19 +183,18 @@ export default function OrdersPage({
                 </div>
 
                 {/* ─── Shipping Address ─────────────────────────────────────────────── */}
-                {order.address && (
+                {order.shipping_address && (
                   <div className="mt-4 text-sm text-[#cfd2d6]">
                     <p className="font-medium text-[var(--foreground)]">
                       Shipping Address:
                     </p>
                     <p>
-                      {order.address.street}
-                      {order.address.line2
-                        ? `, ${order.address.line2}`
-                        : ""}{" "}
-                      {/* 🏠 Line 2 if present */}, {order.address.city},{" "}
-                      {order.address.state} {order.address.zip},{" "}
-                      {order.address.country}
+                      {order.shipping_address.street}
+                      {order.shipping_address.line2
+                        ? `, ${order.shipping_address.line2}`
+                        : ""},{" "}
+                      {order.shipping_address.city}, {order.shipping_address.state}{" "}
+                      {order.shipping_address.zip}, {order.shipping_address.country}
                     </p>
                   </div>
                 )}

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -11,6 +11,7 @@ interface Order {
   customerName: string;
   customerEmail: string;
   customerAddress: string;
+  shipping_address_string?: string;
   items?: { name: string; quantity: number; price: number }[];
   amount: number;
   createdAt: string;
@@ -252,7 +253,9 @@ export default function AdminOrdersPage() {
                 <p className="text-sm mb-2 text-gray-300">
                   🆔 Order ID: {order.stripeSessionId.slice(-8)}
                 </p>
-                <p className="mb-2 text-sm">📍 {order.customerAddress}</p>
+                <p className="mb-2 text-sm">
+                  📍 {order.shipping_address_string || order.customerAddress}
+                </p>
                 <p className="mb-2 text-sm">
                   🧾 Order Date: {new Date(order.createdAt).toLocaleString()}
                 </p>

--- a/pages/api/checkout.ts
+++ b/pages/api/checkout.ts
@@ -35,7 +35,9 @@ export default async function handler(
           price_data: {
             currency: "usd",
             product_data,
-            unit_amount: Math.round(item.price * 100),
+            unit_amount: Math.round(
+              ((item.discountedPrice ?? item.price) as number) * 100
+            ),
           },
           quantity: item.quantity,
         };
@@ -71,7 +73,14 @@ export default async function handler(
         customer_address: addressString,
         notes: notes || "",
         payment_method: paymentMethod || "stripe",
-        items: JSON.stringify(items),
+        items: JSON.stringify(
+          items.map((item: any) => ({
+            name: item.name,
+            quantity: item.quantity,
+            price: item.discountedPrice ?? item.price,
+            image: item.image,
+          }))
+        ),
       },
       // 🖼️ Optional visual branding (set in Stripe dashboard)
       // customer_email: email,  // Optional: prefill email


### PR DESCRIPTION
## Summary
- show discounted prices in Stripe checkout metadata and line items
- display shipping address in orders page using structured fields
- use `shipping_address_string` in admin orders table

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68838cc09fb48330a7b9ff3cb3e6101a