### PR TITLE
Fix shipping address fields and add discounted price to cart

### DIFF
--- a/pages/api/webhook.ts
+++ b/pages/api/webhook.ts
@@ -49,46 +49,38 @@ export default async function handler(
     const metadata = session.metadata || {};
     const items = JSON.parse((metadata.items as string) || "[]");
 
-    const customerName =
-      session.customer_details?.name || metadata.customer_name || "Customer";
-    const customerEmail =
-      session.customer_details?.email ||
-      metadata.customer_email ||
-      process.env.EMAIL_USER;
+    const shippingDetails = session.shipping_details || {};
+    const shipAddr = (shippingDetails as any).address || {};
 
-    // 🏠 Manual address (from metadata)
-    const addressObject = {
-      street: metadata.address_street1 || "",
-      line2: metadata.address_street2 || "",
-      city: metadata.address_city || "",
-      state: metadata.address_state || "",
-      zip: metadata.address_zip || "",
-      country: metadata.address_country || "",
-    };
-
-    const customerAddress = `${addressObject.street}${
-      addressObject.line2 ? `, ${addressObject.line2}` : ""
-    }, ${addressObject.city}, ${addressObject.state} ${addressObject.zip}, ${
-      addressObject.country
-    }`;
-
-    // 📦 Stripe shipping_details (preferred)
-    const shippingDetails = session.shipping_details;
-    const shipName = shippingDetails?.name || "";
-    const shipAddr = shippingDetails?.address || {};
     const shippingAddressObject = {
-      street: (shipAddr as any).line1 || "",
-      line2: (shipAddr as any).line2 || "",
-      city: (shipAddr as any).city || "",
-      state: (shipAddr as any).state || "",
-      zip: (shipAddr as any).postal_code || "",
-      country: (shipAddr as any).country || "",
+      street: (shipAddr as any).line1 || metadata.address_street1 || "",
+      line2: (shipAddr as any).line2 || metadata.address_street2 || "",
+      city: (shipAddr as any).city || metadata.address_city || "",
+      state: (shipAddr as any).state || metadata.address_state || "",
+      zip: (shipAddr as any).postal_code || metadata.address_zip || "",
+      country: (shipAddr as any).country || metadata.address_country || "",
     };
+
     const shippingAddress = `${shippingAddressObject.street}${
       shippingAddressObject.line2 ? `, ${shippingAddressObject.line2}` : ""
     }, ${shippingAddressObject.city}, ${shippingAddressObject.state} ${
       shippingAddressObject.zip
     }, ${shippingAddressObject.country}`;
+
+    const shippingName =
+      (shippingDetails as any).name ||
+      session.customer_details?.name ||
+      metadata.customer_name ||
+      "Customer";
+
+    const customerName = shippingName;
+    const customerEmail =
+      session.customer_details?.email ||
+      metadata.customer_email ||
+      process.env.EMAIL_USER;
+
+    const addressObject = shippingAddressObject;
+    const customerAddress = shippingAddress;
 
     const amountTotal = (session.amount_total || 0) / 100;
     const stripeSessionId = session.id;
@@ -138,7 +130,7 @@ export default async function handler(
         shipped: false,
         delivered: false,
         archived: false,
-        shipping_name: shipName,
+        shipping_name: shippingName,
         shipping_address: shippingAddressObject,
         shipping_address_string: shippingAddress,
       };

--- a/pages/category/[category]/[slug].tsx
+++ b/pages/category/[category]/[slug].tsx
@@ -124,6 +124,7 @@ export default function ProductPage({ product }: { product: ProductType }) {
                   id: product.id,
                   name: product.name,
                   price: product.price,
+                  discountedPrice: product.salePrice ?? undefined,
                   image: product.image,
                   quantity: 1,
                 })

--- a/pages/category/[category]/index.tsx
+++ b/pages/category/[category]/index.tsx
@@ -210,6 +210,7 @@ export default function CategoryPage({
                     id: product._id,
                     name: product.name,
                     price: product.price,
+                    discountedPrice: product.salePrice ?? undefined,
                     image: product.image,
                     quantity: 1,
                   });

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -230,6 +230,7 @@ export default function Home({ products }: HomeProps) {
                             id: item._id,
                             name: item.name,
                             price: item.price,
+                            discountedPrice: item.salePrice ?? undefined,
                             image: item.image,
                             quantity: 1,
                           })
@@ -298,6 +299,7 @@ export default function Home({ products }: HomeProps) {
                           id: item._id,
                           name: item.name,
                           price: item.price,
+                          discountedPrice: item.salePrice ?? undefined,
                           image: item.image,
                           quantity: 1,
                         })

--- a/pages/jewelry.tsx
+++ b/pages/jewelry.tsx
@@ -291,6 +291,7 @@ export default function JewelryPage({ products }: { products: ProductType[] }) {
                     id: product.id,
                     name: product.name,
                     price: product.price,
+                    discountedPrice: product.salePrice ?? undefined,
                     image: product.image,
                     quantity: 1,
                   });

--- a/pages/watches.tsx
+++ b/pages/watches.tsx
@@ -13,6 +13,7 @@ export type ProductType = {
   slug?: string;
   name: string;
   price: number;
+  salePrice?: number;
   image: string;
   category: string;
 };
@@ -183,6 +184,7 @@ export default function WatchesPage({ products }: WatchesProps) {
                     id: product.id,
                     name: product.name,
                     price: product.price,
+                    discountedPrice: product.salePrice ?? undefined,
                     image: product.image,
                     quantity: 1,
                   });


### PR DESCRIPTION
## Summary
- ensure all `addToCart` calls include the optional `discountedPrice` field
- allow `ProductType` for watches to include `salePrice`
- correctly pull shipping name and address from `session.shipping_details` in the webhook

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68839b1f4df08330a47986428a7a3521