### PR TITLE
Align admin pages order card UI

### DIFF
--- a/pages/admin/archived.tsx
+++ b/pages/admin/archived.tsx
@@ -6,12 +6,21 @@ import Link from "next/link";
 import { useSession } from "next-auth/react";
 import Breadcrumbs from "@/components/Breadcrumbs";
 
+interface OrderItem {
+  name: string;
+  quantity: number;
+  price?: number;
+  discountedPrice?: number;
+  salePrice?: number;
+  originalPrice?: number;
+}
+
 interface Order {
   _id: string;
   customerName: string;
   customerEmail: string;
   customerAddress: string;
-  items?: { name: string; quantity: number; price: number }[];
+  items?: OrderItem[];
   amount: number;
   createdAt: string;
   stripeSessionId: string;
@@ -88,10 +97,11 @@ export default function ArchivedOrdersPage() {
       `$${order.amount.toFixed(2)}`,
       new Date(order.createdAt || "").toLocaleString(),
       (order.items || [])
-        .map(
-          (i) =>
-            `${i.quantity}× ${i.name} - $${(i.quantity * i.price).toFixed(2)}`
-        )
+        .map((i) => {
+          const qty = i.quantity ?? 1;
+          const unit = i.price ?? i.originalPrice ?? 0;
+          return `${qty}× ${i.name} - $${(qty * unit).toFixed(2)}`;
+        })
         .join(" | "),
     ]);
 
@@ -191,30 +201,40 @@ export default function ArchivedOrdersPage() {
       ) : (
         <div className="space-y-8">
           {paginatedOrders.map((order) => (
-            <div
-              key={order._id}
-              className="bg-[var(--bg-nav)] p-6 rounded-xl shadow-md hover:shadow-xl hover:scale-105 transition-transform duration-300"
-            >
+            <div key={order._id} className="bg-[var(--bg-nav)] p-6 rounded-xl shadow">
               <h2 className="text-xl font-semibold mb-1">
                 {order.customerName} ({order.customerEmail})
               </h2>
-              <p className="text-sm mb-2 text-gray-300">
-                🔢 Order #: {order.orderNumber ?? "N/A"}
-              </p>
-              <p className="text-sm mb-2 text-gray-300">
-                🆔 Order ID: {order.stripeSessionId.slice(-8)}
+              <p className="text-sm text-gray-300 mb-2">
+                🔢 Order #: {order.orderNumber ?? "N/A"} | 🆔{' '}
+                {order.stripeSessionId.slice(-8)}
               </p>
               <p className="mb-2 text-sm">📍 {order.customerAddress}</p>
-              <p className="mb-2 text-sm">
+              <p className="mb-4 text-sm">
                 🧾 Order Date: {new Date(order.createdAt).toLocaleString()}
               </p>
               <ul className="mb-4 pl-4 list-disc text-sm">
-                {order.items?.map((item, index) => (
-                  <li key={index}>
-                    {item.quantity}× {item.name} – ${" "}
-                    {(item.price * item.quantity).toFixed(2)}
-                  </li>
-                ))}
+                {order.items?.map((item, index) => {
+                  const qty = item.quantity ?? 1;
+                  const basePrice = item.price ?? item.originalPrice ?? 0;
+                  const discountPrice =
+                    item.discountedPrice ?? item.salePrice ?? basePrice;
+                  const orig = basePrice * qty;
+                  const sale = discountPrice * qty;
+                  return (
+                    <li key={index}>
+                      {qty}× {item.name} –{' '}
+                      {discountPrice < basePrice ? (
+                        <>
+                          <span className="line-through">${orig.toFixed(2)}</span>{' '}
+                          <span className="text-green-400">${sale.toFixed(2)}</span>
+                        </>
+                      ) : (
+                        <span>${orig.toFixed(2)}</span>
+                      )}
+                    </li>
+                  );
+                })}
               </ul>
               <div className="flex justify-between items-center">
                 <span className="text-lg font-semibold">
@@ -222,7 +242,7 @@ export default function ArchivedOrdersPage() {
                 </span>
                 <button
                   onClick={() => restoreOrder(order.stripeSessionId)}
-                  className="bg-yellow-600 hover:bg-yellow-700 px-4 py-2 rounded text-sm"
+                  className="bg-yellow-600 px-4 py-2 rounded text-sm"
                 >
                   Restore 🗂️
                 </button>

--- a/pages/admin/completed.tsx
+++ b/pages/admin/completed.tsx
@@ -6,12 +6,21 @@ import Link from "next/link";
 import { useSession } from "next-auth/react";
 import Breadcrumbs from "@/components/Breadcrumbs";
 
+interface OrderItem {
+  name: string;
+  quantity?: number;
+  price?: number;
+  discountedPrice?: number;
+  salePrice?: number;
+  originalPrice?: number;
+}
+
 interface Order {
   _id: string;
   customerName: string;
   customerEmail: string;
   customerAddress: string;
-  items?: { name: string; quantity?: number; price?: number }[];
+  items?: OrderItem[];
   amount: number;
   createdAt: string;
   stripeSessionId: string;
@@ -35,6 +44,7 @@ export default function CompletedOrdersPage() {
   const [trackingInputs, setTrackingInputs] = useState<
     Record<string, { trackingNumber: string; carrier: string }>
   >({});
+  const [savedTracking, setSavedTracking] = useState<Record<string, string>>({});
   const itemsPerPage = 5;
 
   useEffect(() => {
@@ -46,6 +56,11 @@ export default function CompletedOrdersPage() {
       const res = await fetch("/api/admin/completed");
       const data = await res.json();
       setOrders(data.orders || []);
+      const saved: Record<string, string> = {};
+      (data.orders || []).forEach((o: Order) => {
+        if (o.trackingNumber) saved[o.stripeSessionId] = o.trackingNumber;
+      });
+      setSavedTracking(saved);
     } catch (err) {
       console.error("❌ Failed to fetch completed orders:", err);
     } finally {
@@ -82,6 +97,8 @@ export default function CompletedOrdersPage() {
       return;
     }
 
+    if (savedTracking[orderId] === input.trackingNumber) return;
+
     try {
       const adminName =
         session?.user?.firstName || session?.user?.name?.split(" ")[0];
@@ -97,6 +114,10 @@ export default function CompletedOrdersPage() {
       });
       const result = await res.json();
       if (res.ok) {
+        setSavedTracking((prev) => ({
+          ...prev,
+          [orderId]: input.trackingNumber,
+        }));
         fetchCompletedOrders();
       } else {
         alert("❌ " + result.error);
@@ -292,28 +313,17 @@ export default function CompletedOrdersPage() {
           {/* 🧾 Orders */}
           <div id="print-area" className="space-y-10">
             {paginatedOrders.map((order) => (
-              <div
-                key={order._id}
-                className="bg-[var(--bg-nav)] rounded-xl p-6 shadow-md transition-all duration-200"
-              >
+              <div key={order._id} className="bg-[var(--bg-nav)] p-6 rounded-xl shadow">
                 <h2 className="text-xl font-semibold mb-1">
                   {order.customerName} ({order.customerEmail})
                 </h2>
-                <p className="text-sm mb-2 text-gray-300">
-                  🔢 Order #: {order.orderNumber ?? "N/A"}
+                <p className="text-sm text-gray-300 mb-2">
+                  🔢 Order #: {order.orderNumber ?? "N/A"} | 🆔{' '}
+                  {order.stripeSessionId.slice(-8)}
                 </p>
-                <p className="text-sm mb-2 text-gray-300">
-                  🆔 Order ID: {order.stripeSessionId.slice(-8)}
-                </p>
-                <p>
-                  <strong>Address:</strong> {order.customerAddress}
-                </p>
-                <p>
-                  <strong>Total:</strong> ${order.amount.toFixed(2)}
-                </p>
-                <p>
-                  <strong>Shipped At:</strong>{" "}
-                  {new Date(order.shippedAt || "").toLocaleString()}
+                <p className="mb-2">📍 {order.customerAddress}</p>
+                <p className="mb-4">
+                  🧾 Shipped: {new Date(order.shippedAt || "").toLocaleString()}
                 </p>
                 {order.trackingNumber ? (
                   <p>
@@ -365,12 +375,22 @@ export default function CompletedOrdersPage() {
                       }
                       className="px-2 py-1 rounded bg-[#2e3a58] text-white flex-1"
                     />
-                    <button
-                      onClick={() => updateTracking(order.stripeSessionId)}
-                      className="bg-green-600 hover:bg-green-700 px-3 py-1 rounded text-sm"
-                    >
-                      Save Tracking
-                    </button>
+                    {(() => {
+                      const inputVal =
+                        trackingInputs[order.stripeSessionId]?.trackingNumber ||
+                        "";
+                      const isSaved =
+                        !!inputVal && savedTracking[order.stripeSessionId] === inputVal;
+                      return (
+                        <button
+                          onClick={() => updateTracking(order.stripeSessionId)}
+                          disabled={isSaved}
+                          className="bg-green-600 px-3 py-1 rounded text-sm disabled:opacity-50"
+                        >
+                          {isSaved ? "✅ Saved" : "Save Tracking"}
+                        </button>
+                      );
+                    })()}
                   </div>
                 )}
                 <div className="mt-4">
@@ -379,11 +399,22 @@ export default function CompletedOrdersPage() {
                     <ul className="list-disc list-inside space-y-1 mt-2">
                       {order.items.map((item, i) => {
                         const qty = item.quantity ?? 1;
-                        const price = item.price ?? 0;
+                        const basePrice = item.price ?? item.originalPrice ?? 0;
+                        const discountPrice =
+                          item.discountedPrice ?? item.salePrice ?? basePrice;
+                        const orig = basePrice * qty;
+                        const sale = discountPrice * qty;
                         return (
                           <li key={i}>
-                            {item.name || "Unnamed"} × {qty} — $
-                            {(price * qty).toFixed(2)}
+                            {item.name || "Unnamed"} × {qty} —{' '}
+                            {discountPrice < basePrice ? (
+                              <>
+                                <span className="line-through">${orig.toFixed(2)}</span>{' '}
+                                <span className="text-green-400">${sale.toFixed(2)}</span>
+                              </>
+                            ) : (
+                              <span>${orig.toFixed(2)}</span>
+                            )}
                           </li>
                         );
                       })}
@@ -395,19 +426,24 @@ export default function CompletedOrdersPage() {
                   )}
                 </div>
 
-                <div className="mt-4 flex gap-2">
-                  <button
-                    onClick={() => markDelivered(order.stripeSessionId)}
-                    className="bg-blue-600 hover:bg-blue-700 px-4 py-2 rounded text-sm"
-                  >
-                    Delivered 📬
-                  </button>
-                  <button
-                    onClick={() => archiveOrder(order.stripeSessionId)}
-                    className="bg-yellow-600 hover:bg-yellow-700 px-4 py-2 rounded text-sm"
-                  >
-                    Archive 🗂
-                  </button>
+                <div className="flex justify-between items-center mt-4">
+                  <span className="text-lg font-semibold">
+                    💰 Total: ${order.amount.toFixed(2)}
+                  </span>
+                  <div className="space-x-2">
+                    <button
+                      onClick={() => markDelivered(order.stripeSessionId)}
+                      className="bg-blue-600 px-4 py-2 rounded text-sm"
+                    >
+                      Delivered 📬
+                    </button>
+                    <button
+                      onClick={() => archiveOrder(order.stripeSessionId)}
+                      className="bg-yellow-600 px-4 py-2 rounded text-sm"
+                    >
+                      Archive 🗂
+                    </button>
+                  </div>
                 </div>
               </div>
             ))}

--- a/pages/admin/delivered.tsx
+++ b/pages/admin/delivered.tsx
@@ -6,12 +6,21 @@ import Link from "next/link";
 import { useSession } from "next-auth/react";
 import Breadcrumbs from "@/components/Breadcrumbs";
 
+interface OrderItem {
+  name: string;
+  quantity?: number;
+  price?: number;
+  discountedPrice?: number;
+  salePrice?: number;
+  originalPrice?: number;
+}
+
 interface Order {
   _id: string;
   customerName: string;
   customerEmail: string;
   customerAddress: string;
-  items?: { name: string; quantity?: number; price?: number }[];
+  items?: OrderItem[];
   amount: number;
   createdAt: string;
   stripeSessionId: string;
@@ -236,28 +245,17 @@ export default function DeliveredOrdersPage() {
           {/* 🧾 Orders */}
           <div id="print-area" className="space-y-10">
             {paginatedOrders.map((order) => (
-              <div
-                key={order._id}
-                className="bg-[var(--bg-nav)] rounded-xl p-6 shadow-md hover:shadow-xl hover:scale-105 transition-transform duration-300"
-              >
+              <div key={order._id} className="bg-[var(--bg-nav)] p-6 rounded-xl shadow">
                 <h2 className="text-xl font-semibold mb-1">
                   {order.customerName} ({order.customerEmail})
                 </h2>
-                <p className="text-sm mb-2 text-gray-300">
-                  🔢 Order #: {order.orderNumber ?? "N/A"}
+                <p className="text-sm text-gray-300 mb-2">
+                  🔢 Order #: {order.orderNumber ?? "N/A"} | 🆔{' '}
+                  {order.stripeSessionId.slice(-8)}
                 </p>
-                <p className="text-sm mb-2 text-gray-300">
-                  🆔 Order ID: {order.stripeSessionId.slice(-8)}
-                </p>
-                <p>
-                  <strong>Address:</strong> {order.customerAddress}
-                </p>
-                <p>
-                  <strong>Total:</strong> ${order.amount.toFixed(2)}
-                </p>
-                <p>
-                  <strong>Delivered At:</strong>{" "}
-                  {new Date(order.deliveredAt || "").toLocaleString()}
+                <p className="mb-2">📍 {order.customerAddress}</p>
+                <p className="mb-4">
+                  🧾 Delivered: {new Date(order.deliveredAt || "").toLocaleString()}
                 </p>
                 {order.trackingNumber && (
                   <p>
@@ -271,11 +269,22 @@ export default function DeliveredOrdersPage() {
                     <ul className="list-disc list-inside space-y-1 mt-2">
                       {order.items.map((item, i) => {
                         const qty = item.quantity ?? 1;
-                        const price = item.price ?? 0;
+                        const basePrice = item.price ?? item.originalPrice ?? 0;
+                        const discountPrice =
+                          item.discountedPrice ?? item.salePrice ?? basePrice;
+                        const orig = basePrice * qty;
+                        const sale = discountPrice * qty;
                         return (
                           <li key={i}>
-                            {item.name || "Unnamed"} × {qty} — $
-                            {(price * qty).toFixed(2)}
+                            {item.name || "Unnamed"} × {qty} —{' '}
+                            {discountPrice < basePrice ? (
+                              <>
+                                <span className="line-through">${orig.toFixed(2)}</span>{' '}
+                                <span className="text-green-400">${sale.toFixed(2)}</span>
+                              </>
+                            ) : (
+                              <span>${orig.toFixed(2)}</span>
+                            )}
                           </li>
                         );
                       })}
@@ -286,13 +295,17 @@ export default function DeliveredOrdersPage() {
                     </p>
                   )}
                 </div>
-
-                <button
-                  onClick={() => archiveOrder(order.stripeSessionId)}
-                  className="mt-4 bg-yellow-600 hover:bg-yellow-700 px-4 py-2 rounded text-sm"
-                >
-                  Archive 🗂
-                </button>
+                <div className="flex justify-between items-center mt-4">
+                  <span className="text-lg font-semibold">
+                    💰 Total: ${order.amount.toFixed(2)}
+                  </span>
+                  <button
+                    onClick={() => archiveOrder(order.stripeSessionId)}
+                    className="bg-yellow-600 px-4 py-2 rounded text-sm"
+                  >
+                    Archive 🗂
+                  </button>
+                </div>
               </div>
             ))}
           </div>


### PR DESCRIPTION
## Summary
- sync completed/delivered/archived card layouts with main admin page
- format item prices with discount logic across admin pages
- show saved state for tracking number updates

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6887bf9f916c8330bd473a66d7a52d56