### PR TITLE
Fix order item data and display

### DIFF
--- a/pages/account/orders.tsx
+++ b/pages/account/orders.tsx
@@ -188,9 +188,15 @@ export default function OrdersPage({
                   </p>
                   <ul className="space-y-3">
                     {order.items?.map((item: any, idx: number) => {
-                      const original = item.originalPrice ?? item.price ?? 0;
+                      const displayPrice =
+                        item.salePrice ??
+                        item.discountedPrice ??
+                        item.originalPrice ??
+                        item.price ??
+                        0;
+                      const original = item.originalPrice ?? item.price ?? displayPrice;
                       const sale =
-                        item.salePrice ?? item.discountedPrice ?? null;
+                        item.salePrice ?? item.discountedPrice ?? undefined;
                       return (
                         <li key={idx} className="flex items-center gap-4">
                           <Image
@@ -204,22 +210,22 @@ export default function OrdersPage({
                             <p className="font-medium text-[var(--foreground)]">
                               {item.name}
                             </p>
-                            {sale && sale < original ? (
-                              <p className="text-sm text-[#cfd2d6]">
-                                x{item.quantity} –{" "}
-                                <span className="line-through text-gray-400 mr-1">
-                                  ${(original * item.quantity).toFixed(2)}
-                                </span>
-                                <span className="text-green-400 font-semibold">
-                                  ${(sale * item.quantity).toFixed(2)}
-                                </span>
-                              </p>
-                            ) : (
-                              <p className="text-sm text-[#cfd2d6]">
-                                x{item.quantity} – $
-                                {(original * item.quantity).toFixed(2)}
-                              </p>
-                            )}
+                              {sale !== undefined && sale < original ? (
+                                <p className="text-sm text-[#cfd2d6]">
+                                  x{item.quantity} –{" "}
+                                  <span className="line-through text-gray-400 mr-1">
+                                    {(original * item.quantity).toFixed(2)}
+                                  </span>
+                                  <span className="text-green-400 font-semibold">
+                                    {(sale * item.quantity).toFixed(2)}
+                                  </span>
+                                </p>
+                              ) : (
+                                <p className="text-sm text-[#cfd2d6]">
+                                  x{item.quantity} – $
+                                  {(displayPrice * item.quantity).toFixed(2)}
+                                </p>
+                              )}
                           </div>
                         </li>
                       );

--- a/pages/admin/archived.tsx
+++ b/pages/admin/archived.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import Head from "next/head";
 import Link from "next/link";
+import Image from "next/image";
 import { useSession } from "next-auth/react";
 import Breadcrumbs from "@/components/Breadcrumbs";
 
@@ -13,6 +14,7 @@ interface OrderItem {
   discountedPrice?: number;
   salePrice?: number;
   originalPrice?: number;
+  image?: string;
 }
 
 interface Order {
@@ -216,22 +218,35 @@ export default function ArchivedOrdersPage() {
               <ul className="mb-4 pl-4 list-disc text-sm">
                 {order.items?.map((item, index) => {
                   const qty = item.quantity ?? 1;
-                  const basePrice = item.price ?? item.originalPrice ?? 0;
-                  const discountPrice =
-                    item.discountedPrice ?? item.salePrice ?? basePrice;
+                  const displayPrice =
+                    item.salePrice ??
+                    item.discountedPrice ??
+                    item.originalPrice ??
+                    item.price ??
+                    0;
+                  const basePrice = item.originalPrice ?? item.price ?? displayPrice;
                   const orig = basePrice * qty;
-                  const sale = discountPrice * qty;
+                  const sale = displayPrice * qty;
                   return (
-                    <li key={index}>
-                      {qty}× {item.name} –{' '}
-                      {discountPrice < basePrice ? (
-                        <>
-                          <span className="line-through">${orig.toFixed(2)}</span>{' '}
-                          <span className="text-green-400">${sale.toFixed(2)}</span>
-                        </>
-                      ) : (
-                        <span>${orig.toFixed(2)}</span>
-                      )}
+                    <li key={index} className="flex items-center gap-2">
+                      <Image
+                        src={item.image || ""}
+                        alt={item.name}
+                        width={32}
+                        height={32}
+                        className="rounded object-cover"
+                      />
+                      <span>
+                        {qty}× {item.name} –{' '}
+                        {displayPrice < basePrice ? (
+                          <>
+                            <span className="line-through">${orig.toFixed(2)}</span>{' '}
+                            <span className="text-green-400">${sale.toFixed(2)}</span>
+                          </>
+                        ) : (
+                          <span>${sale.toFixed(2)}</span>
+                        )}
+                      </span>
                     </li>
                   );
                 })}

--- a/pages/admin/completed.tsx
+++ b/pages/admin/completed.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import Head from "next/head";
 import Link from "next/link";
+import Image from "next/image";
 import { useSession } from "next-auth/react";
 import Breadcrumbs from "@/components/Breadcrumbs";
 
@@ -13,6 +14,7 @@ interface OrderItem {
   discountedPrice?: number;
   salePrice?: number;
   originalPrice?: number;
+  image?: string;
 }
 
 interface Order {
@@ -399,22 +401,35 @@ export default function CompletedOrdersPage() {
                     <ul className="list-disc list-inside space-y-1 mt-2">
                       {order.items.map((item, i) => {
                         const qty = item.quantity ?? 1;
-                        const basePrice = item.price ?? item.originalPrice ?? 0;
-                        const discountPrice =
-                          item.discountedPrice ?? item.salePrice ?? basePrice;
+                        const displayPrice =
+                          item.salePrice ??
+                          item.discountedPrice ??
+                          item.originalPrice ??
+                          item.price ??
+                          0;
+                        const basePrice = item.originalPrice ?? item.price ?? displayPrice;
                         const orig = basePrice * qty;
-                        const sale = discountPrice * qty;
+                        const sale = displayPrice * qty;
                         return (
-                          <li key={i}>
-                            {item.name || "Unnamed"} × {qty} —{' '}
-                            {discountPrice < basePrice ? (
-                              <>
-                                <span className="line-through">${orig.toFixed(2)}</span>{' '}
-                                <span className="text-green-400">${sale.toFixed(2)}</span>
-                              </>
-                            ) : (
-                              <span>${orig.toFixed(2)}</span>
-                            )}
+                          <li key={i} className="flex items-center gap-2">
+                            <Image
+                              src={item.image || ""}
+                              alt={item.name}
+                              width={32}
+                              height={32}
+                              className="rounded object-cover"
+                            />
+                            <span>
+                              {item.name || 'Unnamed'} × {qty} —{' '}
+                              {displayPrice < basePrice ? (
+                                <>
+                                  <span className="line-through">${orig.toFixed(2)}</span>{' '}
+                                  <span className="text-green-400">${sale.toFixed(2)}</span>
+                                </>
+                              ) : (
+                                <span>${sale.toFixed(2)}</span>
+                              )}
+                            </span>
                           </li>
                         );
                       })}

--- a/pages/admin/delivered.tsx
+++ b/pages/admin/delivered.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import Head from "next/head";
 import Link from "next/link";
+import Image from "next/image";
 import { useSession } from "next-auth/react";
 import Breadcrumbs from "@/components/Breadcrumbs";
 
@@ -13,6 +14,7 @@ interface OrderItem {
   discountedPrice?: number;
   salePrice?: number;
   originalPrice?: number;
+  image?: string;
 }
 
 interface Order {
@@ -269,22 +271,35 @@ export default function DeliveredOrdersPage() {
                     <ul className="list-disc list-inside space-y-1 mt-2">
                       {order.items.map((item, i) => {
                         const qty = item.quantity ?? 1;
-                        const basePrice = item.price ?? item.originalPrice ?? 0;
-                        const discountPrice =
-                          item.discountedPrice ?? item.salePrice ?? basePrice;
+                        const displayPrice =
+                          item.salePrice ??
+                          item.discountedPrice ??
+                          item.originalPrice ??
+                          item.price ??
+                          0;
+                        const basePrice = item.originalPrice ?? item.price ?? displayPrice;
                         const orig = basePrice * qty;
-                        const sale = discountPrice * qty;
+                        const sale = displayPrice * qty;
                         return (
-                          <li key={i}>
-                            {item.name || "Unnamed"} × {qty} —{' '}
-                            {discountPrice < basePrice ? (
-                              <>
-                                <span className="line-through">${orig.toFixed(2)}</span>{' '}
-                                <span className="text-green-400">${sale.toFixed(2)}</span>
-                              </>
-                            ) : (
-                              <span>${orig.toFixed(2)}</span>
-                            )}
+                          <li key={i} className="flex items-center gap-2">
+                            <Image
+                              src={item.image || ""}
+                              alt={item.name}
+                              width={32}
+                              height={32}
+                              className="rounded object-cover"
+                            />
+                            <span>
+                              {item.name || 'Unnamed'} × {qty} —{' '}
+                              {displayPrice < basePrice ? (
+                                <>
+                                  <span className="line-through">${orig.toFixed(2)}</span>{' '}
+                                  <span className="text-green-400">${sale.toFixed(2)}</span>
+                                </>
+                              ) : (
+                                <span>${sale.toFixed(2)}</span>
+                              )}
+                            </span>
                           </li>
                         );
                       })}

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import Head from "next/head";
 import Link from "next/link";
+import Image from "next/image";
 import { useSession } from "next-auth/react";
 import Breadcrumbs from "@/components/Breadcrumbs";
 
@@ -11,6 +12,9 @@ interface OrderItem {
   quantity: number;
   price?: number;
   discountedPrice?: number;
+  salePrice?: number;
+  originalPrice?: number;
+  image?: string;
 }
 
 interface Order {
@@ -287,26 +291,40 @@ export default function AdminOrdersPage() {
             <ul className="mb-4 list-disc pl-4 text-sm">
               {o.items.map((i, idx) => {
                 const qty = i.quantity ?? 1;
-                const basePrice = i.price ?? 0;
-                const discountPrice = i.discountedPrice ?? basePrice;
+                const displayPrice =
+                  i.salePrice ??
+                  i.discountedPrice ??
+                  i.originalPrice ??
+                  i.price ??
+                  0;
+                const basePrice = i.originalPrice ?? i.price ?? displayPrice;
                 const orig = basePrice * qty;
-                const sale = discountPrice * qty;
+                const sale = displayPrice * qty;
 
                 return (
-                  <li key={idx}>
-                    {qty}× {i.name} —{" "}
-                    {discountPrice < basePrice ? (
-                      <>
-                        <span className="line-through text-gray-400 mr-2">
-                          ${orig.toFixed(2)}
-                        </span>
-                        <span className="text-green-400 font-semibold">
-                          ${sale.toFixed(2)}
-                        </span>
-                      </>
-                    ) : (
-                      <span>${orig.toFixed(2)}</span>
-                    )}
+                  <li key={idx} className="flex items-center gap-2">
+                    <Image
+                      src={i.image || ""}
+                      alt={i.name}
+                      width={32}
+                      height={32}
+                      className="rounded object-cover"
+                    />
+                    <span>
+                      {qty}× {i.name} —{' '}
+                      {displayPrice < basePrice ? (
+                        <>
+                          <span className="line-through text-gray-400 mr-2">
+                            ${orig.toFixed(2)}
+                          </span>
+                          <span className="text-green-400 font-semibold">
+                            ${sale.toFixed(2)}
+                          </span>
+                        </>
+                      ) : (
+                        <span>${sale.toFixed(2)}</span>
+                      )}
+                    </span>
                   </li>
                 );
               })}

--- a/pages/api/checkout.ts
+++ b/pages/api/checkout.ts
@@ -127,7 +127,18 @@ export default async function handler(
           items: JSON.stringify(
             items.map((i) => ({
               id: i.id,
-              qty: i.quantity,
+              name: i.name,
+              quantity: i.quantity,
+              originalPrice: i.price,
+              salePrice:
+                i.discountedPrice !== undefined && i.discountedPrice !== null
+                  ? i.discountedPrice
+                  : undefined,
+              discountedPrice:
+                i.discountedPrice !== undefined && i.discountedPrice !== null
+                  ? i.discountedPrice
+                  : undefined,
+              image: i.image,
             }))
           ),
         },

--- a/pages/api/webhook.ts
+++ b/pages/api/webhook.ts
@@ -5,6 +5,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import Stripe from "stripe";
 import nodemailer from "nodemailer";
 import clientPromise from "@/lib/mongodb";
+import { ObjectId } from "mongodb";
 
 export const config = {
   api: {
@@ -58,26 +59,53 @@ export default async function handler(
     const rawItems: Array<{
       id: string;
       name?: string;
-      quantity: number | string;
-      originalPrice?: number | string;
+      quantity?: number | string;
+      originalPrice?: number | string | null;
       salePrice?: number | string | null;
+      discountedPrice?: number | string | null;
       image?: string;
     }> = JSON.parse((metadata.items as string) || "[]");
 
-    const items = rawItems.map((i) => ({
-      id: i.id,
-      name: i.name || "",
-      quantity: Number(i.quantity) || 0,
-      originalPrice: i.originalPrice != null ? Number(i.originalPrice) : 0,
-      salePrice:
-        i.salePrice !== undefined && i.salePrice !== null
-          ? Number(i.salePrice)
-          : undefined,
-      image: i.image || "",
-    }));
-
+    const productIds = rawItems.map((i) => i.id);
     const dbClient = await clientPromise;
     const db = dbClient.db();
+    const products = await db
+      .collection("products")
+      .find({ _id: { $in: productIds.map((id) => new ObjectId(id)) } })
+      .toArray();
+    const productMap = new Map(
+      products.map((p: any) => [p._id.toString(), p])
+    );
+
+    const items = rawItems.map((i) => {
+      const product: any = productMap.get(i.id) || {};
+      const original =
+        i.originalPrice != null
+          ? Number(i.originalPrice)
+          : product.price != null
+          ? Number(product.price)
+          : 0;
+      const sale =
+        i.salePrice != null
+          ? Number(i.salePrice)
+          : i.discountedPrice != null
+          ? Number(i.discountedPrice)
+          : product.salePrice != null
+          ? Number(product.salePrice)
+          : undefined;
+
+      const item: any = {
+        name: i.name || product.name || "",
+        image: i.image || product.imageUrl || product.image || "",
+        quantity: Number(i.quantity) || 1,
+        originalPrice: original,
+      };
+      if (sale !== undefined) {
+        item.salePrice = sale;
+        item.discountedPrice = sale;
+      }
+      return item;
+    });
 
     // ✅ Prefer Stripe shipping_details, then customer_details, then metadata
     const stripeAddr =
@@ -174,7 +202,11 @@ export default async function handler(
       const itemRows = items
         .map((item: any) => {
           const price =
-            item.salePrice ?? item.originalPrice ?? item.price ?? 0;
+            item.salePrice ??
+            item.discountedPrice ??
+            item.originalPrice ??
+            item.price ??
+            0;
           return `
           <tr>
             <td style="padding: 8px; border: 1px solid #ddd;">


### PR DESCRIPTION
## Summary
- include complete item fields in checkout metadata
- populate item data from DB in webhook
- handle sale & original prices on order display
- show images and prices on admin pages

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6887d0222ee48330871582b745ce2179