### PR TITLE
Prevent duplicate tracking emails

### DIFF
--- a/pages/admin/completed.tsx
+++ b/pages/admin/completed.tsx
@@ -30,6 +30,7 @@ interface Order {
   shippedAt?: string;
   trackingNumber?: string;
   carrier?: string;
+  trackingEmailSentAt?: string;
   delivered?: boolean;
   deliveredAt?: string;
   archived?: boolean;
@@ -47,6 +48,7 @@ export default function CompletedOrdersPage() {
     Record<string, { trackingNumber: string; carrier: string }>
   >({});
   const [savedTracking, setSavedTracking] = useState<Record<string, string>>({});
+  const [savingTracking, setSavingTracking] = useState<Record<string, boolean>>({});
   const itemsPerPage = 5;
 
   useEffect(() => {
@@ -102,6 +104,7 @@ export default function CompletedOrdersPage() {
     if (savedTracking[orderId] === input.trackingNumber) return;
 
     try {
+      setSavingTracking((p) => ({ ...p, [orderId]: true }));
       const adminName =
         session?.user?.firstName || session?.user?.name?.split(" ")[0];
       const res = await fetch("/api/tracking", {
@@ -120,12 +123,15 @@ export default function CompletedOrdersPage() {
           ...prev,
           [orderId]: input.trackingNumber,
         }));
+        alert("✅ Tracking saved and email sent.");
         fetchCompletedOrders();
       } else {
         alert("❌ " + result.error);
       }
     } catch (err) {
       console.error("❌ Error updating tracking:", err);
+    } finally {
+      setSavingTracking((p) => ({ ...p, [orderId]: false }));
     }
   };
 
@@ -379,17 +385,17 @@ export default function CompletedOrdersPage() {
                     />
                     {(() => {
                       const inputVal =
-                        trackingInputs[order.stripeSessionId]?.trackingNumber ||
-                        "";
+                        trackingInputs[order.stripeSessionId]?.trackingNumber || "";
                       const isSaved =
                         !!inputVal && savedTracking[order.stripeSessionId] === inputVal;
+                      const isSaving = savingTracking[order.stripeSessionId];
                       return (
                         <button
                           onClick={() => updateTracking(order.stripeSessionId)}
-                          disabled={isSaved}
+                          disabled={isSaved || isSaving}
                           className="bg-green-600 px-3 py-1 rounded text-sm disabled:opacity-50"
                         >
-                          {isSaved ? "✅ Saved" : "Save Tracking"}
+                          {isSaved ? "✅ Saved" : isSaving ? "Saving..." : "Save Tracking"}
                         </button>
                       );
                     })()}

--- a/pages/admin/delivered.tsx
+++ b/pages/admin/delivered.tsx
@@ -30,6 +30,7 @@ interface Order {
   shippedAt?: string;
   trackingNumber?: string;
   carrier?: string;
+  trackingEmailSentAt?: string;
   delivered?: boolean;
   deliveredAt?: string;
   archived?: boolean;

--- a/pages/api/admin/completed.ts
+++ b/pages/api/admin/completed.ts
@@ -40,6 +40,9 @@ export default async function handler(
       archived: o.archived ?? false,
       orderNumber: o.orderNumber,
       stripeSessionId: o.stripeSessionId,
+      trackingNumber: o.trackingNumber,
+      carrier: o.carrier,
+      trackingEmailSentAt: o.trackingEmailSentAt,
 
       items: (o.items || []).map((i: any) => ({
         name: i.name,

--- a/pages/api/admin/delivered.ts
+++ b/pages/api/admin/delivered.ts
@@ -39,6 +39,9 @@ export default async function handler(
       archived: o.archived ?? false,
       orderNumber: o.orderNumber,
       stripeSessionId: o.stripeSessionId,
+      trackingNumber: o.trackingNumber,
+      carrier: o.carrier,
+      trackingEmailSentAt: o.trackingEmailSentAt,
 
       // remapped items
       items: (o.items || []).map((i: any) => ({

--- a/pages/api/tracking.ts
+++ b/pages/api/tracking.ts
@@ -28,6 +28,8 @@ export default async function handler(
       return res.status(404).json({ error: "Order not found" });
     }
 
+    const isFirstTracking = !order.trackingNumber;
+
     await db.collection("orders").updateOne(
       { stripeSessionId: orderId },
       {
@@ -35,6 +37,7 @@ export default async function handler(
           trackingNumber,
           carrier: carrier || "",
           trackingUpdatedAt: new Date(),
+          ...(isFirstTracking ? { trackingEmailSentAt: new Date() } : {}),
         },
       }
     );
@@ -79,15 +82,19 @@ export default async function handler(
         </p>
       </div>`;
 
-    await transporter.sendMail({
-      from: `"Classy Diamonds" <${process.env.EMAIL_USER}>`,
-      to: order.customerEmail,
-      subject: "📦 Your Tracking Number",
-      html,
-    });
+    if (isFirstTracking) {
+      await transporter.sendMail({
+        from: `"Classy Diamonds" <${process.env.EMAIL_USER}>`,
+        to: order.customerEmail,
+        subject: "📦 Your Tracking Number",
+        html,
+      });
+      console.log("📧 Tracking email sent to:", order.customerEmail);
+    } else {
+      console.log("ℹ️ Tracking updated without resending email for:", order.customerEmail);
+    }
 
-    console.log("📧 Tracking email sent to:", order.customerEmail);
-    return res.status(200).json({ success: true });
+    return res.status(200).json({ success: true, emailSent: isFirstTracking });
   } catch (err) {
     console.error("❌ Tracking update error:", err);
     return res.status(500).json({ error: "Server error" });


### PR DESCRIPTION
## Summary
- include tracking fields in admin order APIs
- prevent duplicate emails on tracking update
- show success alert and disable "Save Tracking" button while saving

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6888d78d42a083309e9d1665e6dc3bb9