### PR TITLE
Show placeholder images in admin pages

### DIFF
--- a/pages/admin/archived.tsx
+++ b/pages/admin/archived.tsx
@@ -230,11 +230,16 @@ export default function ArchivedOrdersPage() {
                   return (
                     <li key={index} className="flex items-center gap-2">
                       <Image
-                        src={item.image || ""}
+                        src={item.image || "/products/placeholder.jpg"}
                         alt={item.name}
                         width={48}
                         height={48}
                         className="rounded object-cover"
+                        onError={(e) => {
+                          const target = e.currentTarget as HTMLImageElement;
+                          target.src = "/products/placeholder.jpg";
+                        }}
+                        unoptimized
                       />
                       <span>
                         {item.name} – x{qty} –{' '}

--- a/pages/admin/completed.tsx
+++ b/pages/admin/completed.tsx
@@ -419,11 +419,16 @@ export default function CompletedOrdersPage() {
                         return (
                           <li key={i} className="flex items-center gap-2">
                             <Image
-                              src={item.image || ""}
+                              src={item.image || "/products/placeholder.jpg"}
                               alt={item.name}
                               width={48}
                               height={48}
                               className="rounded object-cover"
+                              onError={(e) => {
+                                const target = e.currentTarget as HTMLImageElement;
+                                target.src = "/products/placeholder.jpg";
+                              }}
+                              unoptimized
                             />
                             <span>
                               {item.name || 'Unnamed'} – x{qty} –{' '}

--- a/pages/admin/delivered.tsx
+++ b/pages/admin/delivered.tsx
@@ -284,11 +284,16 @@ export default function DeliveredOrdersPage() {
                         return (
                           <li key={i} className="flex items-center gap-2">
                             <Image
-                              src={item.image || ""}
+                              src={item.image || "/products/placeholder.jpg"}
                               alt={item.name}
                               width={48}
                               height={48}
                               className="rounded object-cover"
+                              onError={(e) => {
+                                const target = e.currentTarget as HTMLImageElement;
+                                target.src = "/products/placeholder.jpg";
+                              }}
+                              unoptimized
                             />
                             <span>
                               {item.name || 'Unnamed'} – x{qty} –{' '}

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -310,11 +310,16 @@ export default function AdminOrdersPage() {
                 return (
                   <li key={idx} className="flex items-center gap-2">
                     <Image
-                      src={i.image || ""}
+                      src={i.image || "/products/placeholder.jpg"}
                       alt={i.name}
                       width={48}
                       height={48}
                       className="rounded object-cover"
+                      onError={(e) => {
+                        const target = e.currentTarget as HTMLImageElement;
+                        target.src = "/products/placeholder.jpg";
+                      }}
+                      unoptimized
                     />
                     <span>
                       {i.name} – x{qty} –{' '}


### PR DESCRIPTION
## Summary
- fix image columns in Admin order views by falling back to a placeholder image when an item has no image
- ensure broken images automatically swap to the placeholder
- allow loading remote images without Next optimization

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6888de712c3c8330a820adda4b50f25e