### PR TITLE
Fix watch page routing

### DIFF
--- a/pages/watches.tsx
+++ b/pages/watches.tsx
@@ -7,6 +7,7 @@ import { useCart } from "@/context/CartContext";
 import { GetServerSideProps } from "next";
 import clientPromise from "@/lib/mongodb";
 import Breadcrumbs from "@/components/Breadcrumbs";
+import { jewelryData } from "@/data/jewelryData";
 
 export type ProductType = {
   id: string;
@@ -124,10 +125,19 @@ export default function WatchesPage({ products }: WatchesProps) {
     },
   ];
 
+  const staticWatches: ProductType[] = jewelryData
+    .filter((p) => p.category === "watches")
+    .map((p) => ({
+      id: p.id.toString(),
+      slug: p.slug,
+      name: p.name,
+      price: p.price,
+      image: p.image,
+      category: p.category,
+    }));
+
   const watchProducts =
-    products.length >= 12
-      ? products.slice(0, 12)
-      : [...products, ...placeholders].slice(0, 12);
+    [...staticWatches, ...products, ...placeholders].slice(0, 12);
 
   return (
     <div className="min-h-screen flex flex-col bg-[var(--bg-page)] text-[var(--foreground)]">

--- a/pages/watches/[slug].tsx
+++ b/pages/watches/[slug].tsx
@@ -6,6 +6,7 @@ import Image from "next/image";
 import { useCart } from "@/context/CartContext";
 import clientPromise from "@/lib/mongodb";
 import Breadcrumbs from "@/components/Breadcrumbs";
+import { jewelryData } from "@/data/jewelryData";
 
 export type WatchProduct = {
   id: string;
@@ -88,18 +89,33 @@ export const getServerSideProps: GetServerSideProps = async ({ params }) => {
   const slug = params?.slug as string;
   const client = await clientPromise;
   const p = await client.db().collection("products").findOne({ slug });
-  if (!p) {
-    return { notFound: true };
+  let product: WatchProduct | null = null;
+  if (p) {
+    product = {
+      id: p._id.toString(),
+      skuNumber: p.skuNumber ?? null,
+      name: p.name,
+      price: p.price,
+      salePrice: p.salePrice ?? null,
+      image: p.imageUrl || p.image,
+      slug: p.slug,
+      description: p.description || "",
+    };
+  } else {
+    const fallback = jewelryData.find((item) => item.slug === slug);
+    if (!fallback) {
+      return { notFound: true };
+    }
+    product = {
+      id: fallback.id.toString(),
+      skuNumber: fallback.id,
+      name: fallback.name,
+      price: fallback.price,
+      salePrice: (fallback as any).salePrice ?? null,
+      image: fallback.image,
+      slug: fallback.slug,
+      description: (fallback as any).description ?? "",
+    };
   }
-  const product: WatchProduct = {
-    id: p._id.toString(),
-    skuNumber: p.skuNumber ?? null,
-    name: p.name,
-    price: p.price,
-    salePrice: p.salePrice ?? null,
-    image: p.imageUrl || p.image,
-    slug: p.slug,
-    description: p.description || "",
-  };
   return { props: { product } };
 };


### PR DESCRIPTION
## Summary
- load fallback watch data from jewelryData
- show fallback watch details if MongoDB lookup fails

## Testing
- `npm install`
- `npx next lint`

------
https://chatgpt.com/codex/tasks/task_e_6888eb9e90cc833095325d92b2716281