### PR TITLE
Fix consistent image sizing on slug pages

### DIFF
--- a/pages/category/[category]/[slug].tsx
+++ b/pages/category/[category]/[slug].tsx
@@ -79,14 +79,13 @@ export default function ProductPage({ product }: { product: ProductType }) {
         {/* 📦 Product Details */}
         <section className="pt-10 pb-16 px-6 max-w-7xl mx-auto flex flex-col md:flex-row items-center gap-12">
           {/* 🖼 Product Image */}
-          <div className="w-full md:w-1/2 overflow-hidden rounded-2xl shadow-lg bg-[var(--bg-nav)]">
+          <div className="w-full md:w-1/2 max-w-[600px] aspect-square relative overflow-hidden rounded-2xl shadow-lg bg-[var(--bg-nav)]">
             <Image
               src={product.image}
               alt={`Photo of ${product.name}`}
-              width={600}
-              height={600}
+              fill
               sizes="(min-width: 768px) 50vw, 100vw"
-              className="object-cover w-full h-full"
+              className="object-cover"
               priority
             />
           </div>

--- a/pages/watches/[slug].tsx
+++ b/pages/watches/[slug].tsx
@@ -36,14 +36,13 @@ export default function WatchPage({ product }: { product: WatchProduct }) {
           />
         </div>
         <section className="pt-10 pb-16 px-6 max-w-7xl mx-auto flex flex-col md:flex-row items-center gap-12">
-          <div className="w-full md:w-1/2 overflow-hidden rounded-2xl shadow-lg bg-[var(--bg-nav)]">
+          <div className="w-full md:w-1/2 max-w-[600px] aspect-square relative overflow-hidden rounded-2xl shadow-lg bg-[var(--bg-nav)]">
             <Image
               src={product.image}
               alt={`Photo of ${product.name}`}
-              width={600}
-              height={600}
+              fill
               sizes="(min-width: 768px) 50vw, 100vw"
-              className="object-cover w-full h-full"
+              className="object-cover"
               priority
             />
           </div>


### PR DESCRIPTION
## Summary
- standardize product image containers on slug pages

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6888ff215a588330bd52b3b7e401514c