### PR TITLE
Remove static jewelry data

### DIFF
--- a/pages/category/[category]/[slug].tsx
+++ b/pages/category/[category]/[slug].tsx
@@ -77,7 +77,7 @@ export default function ProductPage({ product }: { product: ProductType }) {
         </div>
 
         {/* 📦 Product Details */}
-        <section className="pt-10 pb-16 px-6 max-w-7xl mx-auto flex flex-col md:flex-row items-center gap-12">
+        <section className="pt-14 pb-20 px-4 md:px-8 max-w-5xl mx-auto flex flex-col md:flex-row items-center gap-16">
           {/* 🖼 Product Image */}
           <div className="w-full md:w-1/2 max-w-[600px] aspect-square relative overflow-hidden rounded-2xl shadow-lg bg-[var(--bg-nav)]">
             <Image
@@ -91,7 +91,7 @@ export default function ProductPage({ product }: { product: ProductType }) {
           </div>
 
           {/* 📋 Product Info */}
-          <div className="w-full md:w-1/2 flex flex-col gap-6">
+          <div className="w-full md:w-1/2 flex flex-col gap-8">
             <h1 className="text-4xl font-bold text-[var(--foreground)]">
               {product.name}
             </h1>

--- a/pages/category/[category]/index.tsx
+++ b/pages/category/[category]/index.tsx
@@ -7,7 +7,6 @@ import Link from "next/link";
 import { useState, useRef, useEffect } from "react";
 import { useRouter } from "next/router";
 import { useCart } from "@/context/CartContext";
-import { jewelryData } from "@/data/jewelryData"; // static data
 import Breadcrumbs from "@/components/Breadcrumbs";
 
 interface Product {
@@ -32,7 +31,7 @@ export const getServerSideProps: GetServerSideProps<
 > = async ({ query }) => {
   const cat = query.category as string;
   const res = await fetch(
-    `${process.env.NEXTAUTH_URL}/api/products?category=${cat}`
+    `${process.env.NEXTAUTH_URL}/api/products?category=${cat}`,
   );
   const products: Product[] = await res.json();
   return { props: { products, category: cat } };
@@ -48,26 +47,14 @@ export default function CategoryPage({
   const titleRef = useRef<HTMLHeadingElement>(null);
   const router = useRouter();
 
-  // Normalize static data to Product[]
-  const staticProducts: Product[] = jewelryData
-    .filter((p) => p.category.toLowerCase() === category.toLowerCase())
-    .map((p) => ({
-      _id: p.id.toString(), // convert number to string id
-      name: p.name,
-      price: p.price,
-      image: p.image,
-      category: p.category,
-      slug: p.slug,
-    }));
-
-  // Merge both sets
-  const allProducts: Product[] = [...staticProducts, ...products];
+  // Use only products from the database
+  const allProducts: Product[] = products;
 
   const handleLoadMore = () => {
     setVisibleCount((prev) => prev + 4);
     setTimeout(
       () => productsEndRef.current?.scrollIntoView({ behavior: "smooth" }),
-      300
+      300,
     );
   };
 
@@ -166,63 +153,67 @@ export default function CategoryPage({
         >
           {prettyCategory} Pieces
         </h2>
-        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-6 auto-rows-fr">
-          {allProducts.slice(0, visibleCount).map((product) => (
-            <div key={product._id} className="group">
-              <div className="bg-[var(--bg-nav)] rounded-2xl overflow-hidden shadow-lg hover:ring-2 hover:ring-[var(--foreground)] hover:scale-105 transition-transform duration-300 flex flex-col h-full justify-between">
-                {/* 🔗 Product Link & Image */}
-                <Link
-                  href={`/category/${product.category}/${product.slug}`}
-                  className="flex-1 flex flex-col h-full"
-                >
-                <div className="product-card-img">
-                  <Image
-                    src={product.image}
-                    alt={product.name}
-                    fill
-                    className="object-cover group-hover:scale-110 transition h-full w-full"
-                  />
+        {allProducts.length === 0 ? (
+          <div className="text-center text-gray-400">No products found.</div>
+        ) : (
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-6 auto-rows-fr">
+            {allProducts.slice(0, visibleCount).map((product) => (
+              <div key={product._id} className="group">
+                <div className="bg-[var(--bg-nav)] rounded-2xl overflow-hidden shadow-lg hover:ring-2 hover:ring-[var(--foreground)] hover:scale-105 transition-transform duration-300 flex flex-col h-full justify-between">
+                  {/* 🔗 Product Link & Image */}
+                  <Link
+                    href={`/category/${product.category}/${product.slug}`}
+                    className="flex-1 flex flex-col h-full"
+                  >
+                    <div className="product-card-img">
+                      <Image
+                        src={product.image}
+                        alt={product.name}
+                        fill
+                        className="object-cover group-hover:scale-110 transition h-full w-full"
+                      />
+                    </div>
+                    <div className="p-4 text-center flex-1 flex flex-col justify-between">
+                      <h3 className="font-semibold text-[var(--foreground)] truncate text-sm">
+                        {product.name}
+                      </h3>
+                      <p className="text-[#cfd2d6] text-sm">
+                        {product.salePrice ? (
+                          <>
+                            <span className="line-through mr-1">
+                              ${product.price.toLocaleString()}
+                            </span>
+                            <span className="text-red-500">
+                              ${product.salePrice.toLocaleString()}
+                            </span>
+                          </>
+                        ) : (
+                          <>${product.price.toLocaleString()}</>
+                        )}
+                      </p>
+                    </div>
+                  </Link>
+                  <button
+                    onClick={(e) => {
+                      e.preventDefault();
+                      addToCart({
+                        id: product._id,
+                        name: product.name,
+                        price: product.salePrice ?? product.price,
+                        discountedPrice: product.salePrice ?? undefined,
+                        image: product.image,
+                        quantity: 1,
+                      });
+                    }}
+                    className="m-4 px-6 py-3 bg-[#e0e0e0] text-[#1f2a44] rounded-xl hover:scale-105 transition"
+                  >
+                    Add to Cart
+                  </button>
                 </div>
-                <div className="p-4 text-center flex-1 flex flex-col justify-between">
-                  <h3 className="font-semibold text-[var(--foreground)] truncate text-sm">
-                    {product.name}
-                  </h3>
-                  <p className="text-[#cfd2d6] text-sm">
-                    {product.salePrice ? (
-                      <>
-                        <span className="line-through mr-1">
-                          ${product.price.toLocaleString()}
-                        </span>
-                        <span className="text-red-500">
-                          ${product.salePrice.toLocaleString()}
-                        </span>
-                      </>
-                    ) : (
-                      <>${product.price.toLocaleString()}</>
-                    )}
-                  </p>
-                </div>
-              </Link>
-              <button
-                onClick={(e) => {
-                  e.preventDefault();
-                  addToCart({
-                    id: product._id,
-                    name: product.name,
-                    price: product.salePrice ?? product.price,
-                    discountedPrice: product.salePrice ?? undefined,
-                    image: product.image,
-                    quantity: 1,
-                  });
-                }}
-                className="m-4 px-6 py-3 bg-[#e0e0e0] text-[#1f2a44] rounded-xl hover:scale-105 transition"
-              >
-                Add to Cart
-              </button>
-            </div>
+              </div>
+            ))}
           </div>
-          ))}
-        </div>
+        )}
         {/* 🔽 Load More */}
         <div ref={productsEndRef} />
         {visibleCount < allProducts.length ? (

--- a/pages/watches.tsx
+++ b/pages/watches.tsx
@@ -7,7 +7,6 @@ import { useCart } from "@/context/CartContext";
 import { GetServerSideProps } from "next";
 import clientPromise from "@/lib/mongodb";
 import Breadcrumbs from "@/components/Breadcrumbs";
-import { jewelryData } from "@/data/jewelryData";
 
 export type ProductType = {
   id: string;
@@ -26,118 +25,7 @@ interface WatchesProps {
 export default function WatchesPage({ products }: WatchesProps) {
   const { addToCart } = useCart();
 
-  const placeholders: ProductType[] = [
-    {
-      id: "p1",
-      name: "Classic Gold Watch",
-      price: 899,
-      image: "/products/placeholder.jpg",
-      slug: "#",
-      category: "watches",
-    },
-    {
-      id: "p2",
-      name: "Elegant Silver Watch",
-      price: 799,
-      image: "/products/placeholder.jpg",
-      slug: "#",
-      category: "watches",
-    },
-    {
-      id: "p3",
-      name: "Modern Chronograph",
-      price: 999,
-      image: "/products/placeholder.jpg",
-      slug: "#",
-      category: "watches",
-    },
-    {
-      id: "p4",
-      name: "Vintage Leather Watch",
-      price: 650,
-      image: "/products/placeholder.jpg",
-      slug: "#",
-      category: "watches",
-    },
-    {
-      id: "p5",
-      name: "Minimalist Steel Watch",
-      price: 720,
-      image: "/products/placeholder.jpg",
-      slug: "#",
-      category: "watches",
-    },
-    {
-      id: "p6",
-      name: "Luxury Diamond Watch",
-      price: 1500,
-      image: "/products/placeholder.jpg",
-      slug: "#",
-      category: "watches",
-    },
-    {
-      id: "p7",
-      name: "Sporty Digital Watch",
-      price: 550,
-      image: "/products/placeholder.jpg",
-      slug: "#",
-      category: "watches",
-    },
-    {
-      id: "p8",
-      name: "Sleek Ceramic Watch",
-      price: 1100,
-      image: "/products/placeholder.jpg",
-      slug: "#",
-      category: "watches",
-    },
-    {
-      id: "p9",
-      name: "Bold Diver Watch",
-      price: 950,
-      image: "/products/placeholder.jpg",
-      slug: "#",
-      category: "watches",
-    },
-    {
-      id: "p10",
-      name: "Retro Quartz Watch",
-      price: 480,
-      image: "/products/placeholder.jpg",
-      slug: "#",
-      category: "watches",
-    },
-    {
-      id: "p11",
-      name: "Automatic GMT Watch",
-      price: 1300,
-      image: "/products/placeholder.jpg",
-      slug: "#",
-      category: "watches",
-    },
-    {
-      id: "p12",
-      name: "Premium Titanium Watch",
-      price: 1750,
-      image: "/products/placeholder.jpg",
-      slug: "#",
-      category: "watches",
-    },
-  ];
-
-  const staticWatches: ProductType[] = jewelryData
-    .filter((p) => p.category === "watches")
-    .map((p) => ({
-      id: p.id.toString(),
-      slug: p.slug,
-      name: p.name,
-      price: p.price,
-      image: p.image,
-      category: p.category,
-    }));
-
-  const watchProducts =
-    [...staticWatches, ...products, ...placeholders].slice(0, 12);
+  const watchProducts = products;
 
   return (
     <div className="min-h-screen flex flex-col bg-[var(--bg-page)] text-[var(--foreground)]">
@@ -172,61 +60,63 @@ export default function WatchesPage({ products }: WatchesProps) {
         <Breadcrumbs />
       </div>
 
-      <section className="pt-20 pb-12 px-4 sm:px-6 max-w-7xl mx-auto">
+      <section className="pt-20 pb-20 px-4 sm:px-6 max-w-7xl mx-auto">
         <h1 className="text-3xl font-serif font-semibold tracking-wide text-white text-center mb-8">
           Watches
         </h1>
 
-        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-6 auto-rows-fr">
-          {watchProducts.map((product) => (
-            <div
-              key={product.id}
-              className="group bg-[var(--bg-nav)] rounded-2xl overflow-hidden shadow-md hover:shadow-2xl hover:scale-105 transition-transform duration-300 flex flex-col h-full justify-between"
-            >
-              <Link
-                href={
-                  product.slug && product.slug !== "#"
-                    ? `/watches/${product.slug}`
-                    : "#"
-                }
-                className="flex-1 flex flex-col h-full"
-              >
-                <div className="product-card-img">
-                  <Image
-                    src={product.image}
-                    alt={product.name}
-                    fill
-                    className="object-cover group-hover:scale-110 transition h-full w-full"
-                  />
+        {watchProducts.length === 0 ? (
+          <div className="text-center text-gray-400">No watches available.</div>
+        ) : (
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-6 auto-rows-fr">
+            {watchProducts.map((product) => {
+              return (
+                <div
+                  key={product.id}
+                  className="group bg-[var(--bg-nav)] rounded-2xl overflow-hidden shadow-md hover:shadow-2xl hover:scale-105 transition-transform duration-300 flex flex-col h-full justify-between"
+                >
+                  <Link
+                    href={`/watches/${product.slug}`}
+                    className="flex-1 flex flex-col h-full"
+                  >
+                    <div className="product-card-img">
+                      <Image
+                        src={product.image}
+                        alt={product.name}
+                        fill
+                        className="object-cover group-hover:scale-110 transition h-full w-full"
+                      />
+                    </div>
+                    <div className="p-4 text-center flex-1 flex flex-col justify-between">
+                      <h3 className="font-semibold text-[var(--foreground)] truncate text-sm tracking-wide leading-snug">
+                        {product.name}
+                      </h3>
+                      <p className="text-[#cfd2d6] text-sm">
+                        ${product.price.toLocaleString()}
+                      </p>
+                    </div>
+                  </Link>
+                  <button
+                    onClick={(e) => {
+                      e.preventDefault();
+                      addToCart({
+                        id: product.id,
+                        name: product.name,
+                        price: product.price,
+                        discountedPrice: product.salePrice,
+                        image: product.image,
+                        quantity: 1,
+                      });
+                    }}
+                    className="m-4 px-6 py-3 bg-[#e0e0e0] text-[#1f2a44] rounded-xl hover:scale-105 transition"
+                  >
+                    Add to Cart
+                  </button>
                 </div>
-                <div className="p-4 text-center flex-1 flex flex-col justify-between">
-                  <h3 className="font-semibold text-[var(--foreground)] truncate text-sm tracking-wide leading-snug">
-                    {product.name}
-                  </h3>
-                  <p className="text-[#cfd2d6] text-sm">
-                    ${product.price.toLocaleString()}
-                  </p>
-                </div>
-              </Link>
-              <button
-                onClick={(e) => {
-                  e.preventDefault();
-                  addToCart({
-                    id: product.id,
-                    name: product.name,
-                    price: product.price, // ← original price
-                    discountedPrice: product.salePrice, // ← sale price (or undefined)
-                    image: product.image,
-                    quantity: 1,
-                  });
-                }}
-                className="m-4 px-6 py-3 bg-[#e0e0e0] text-[#1f2a44] rounded-xl hover:scale-105 transition"
-              >
-                Add to Cart
-              </button>
-            </div>
-          ))}
-        </div>
+              );
+            })}
+          </div>
+        )}
       </section>
     </div>
   );

--- a/pages/watches/[slug].tsx
+++ b/pages/watches/[slug].tsx
@@ -6,7 +6,6 @@ import Image from "next/image";
 import { useCart } from "@/context/CartContext";
 import clientPromise from "@/lib/mongodb";
 import Breadcrumbs from "@/components/Breadcrumbs";
-import { jewelryData } from "@/data/jewelryData";
 
 export type WatchProduct = {
   id: string;
@@ -26,16 +25,22 @@ export default function WatchPage({ product }: { product: WatchProduct }) {
     <>
       <Head>
         <title>{product.name} | Classy Diamonds</title>
-        <meta name="description" content={product.description || product.name} />
+        <meta
+          name="description"
+          content={product.description || product.name}
+        />
       </Head>
       <div className="min-h-screen flex flex-col bg-[var(--bg-page)] text-[var(--foreground)]">
         <div className="pl-4 pr-4 sm:pl-8 sm:pr-8 mt-6 mb-6">
           <Breadcrumbs
             customLabels={{ watches: "Watches", [product.slug]: product.name }}
-            customPaths={{ watches: "/watches", [product.slug]: `/watches/${product.slug}` }}
+            customPaths={{
+              watches: "/watches",
+              [product.slug]: `/watches/${product.slug}`,
+            }}
           />
         </div>
-        <section className="pt-10 pb-16 px-6 max-w-7xl mx-auto flex flex-col md:flex-row items-center gap-12">
+        <section className="pt-14 pb-20 px-4 md:px-8 max-w-5xl mx-auto flex flex-col md:flex-row items-center gap-16">
           <div className="w-full md:w-1/2 max-w-[600px] aspect-square relative overflow-hidden rounded-2xl shadow-lg bg-[var(--bg-nav)]">
             <Image
               src={product.image}
@@ -46,17 +51,27 @@ export default function WatchPage({ product }: { product: WatchProduct }) {
               priority
             />
           </div>
-          <div className="w-full md:w-1/2 flex flex-col gap-6">
-            <h1 className="text-4xl font-bold text-[var(--foreground)]">{product.name}</h1>
+          <div className="w-full md:w-1/2 flex flex-col gap-8">
+            <h1 className="text-4xl font-bold text-[var(--foreground)]">
+              {product.name}
+            </h1>
             {product.skuNumber !== undefined && (
-              <p className="text-sm text-gray-400">SKU # {String(product.skuNumber).padStart(5, "0")}</p>
+              <p className="text-sm text-gray-400">
+                SKU # {String(product.skuNumber).padStart(5, "0")}
+              </p>
             )}
-            <p className="text-lg text-[#cfd2d6]">{product.description || "Beautiful handcrafted timepiece."}</p>
+            <p className="text-lg text-[#cfd2d6]">
+              {product.description || "Beautiful handcrafted timepiece."}
+            </p>
             <p className="text-2xl font-semibold text-[var(--foreground)]">
               {product.salePrice ? (
                 <>
-                  <span className="line-through mr-2 text-xl">${product.price.toLocaleString()}</span>
-                  <span className="text-green-500">${product.salePrice.toLocaleString()}</span>
+                  <span className="line-through mr-2 text-xl">
+                    ${product.price.toLocaleString()}
+                  </span>
+                  <span className="text-green-500">
+                    ${product.salePrice.toLocaleString()}
+                  </span>
                 </>
               ) : (
                 <>${product.price.toLocaleString()}</>
@@ -88,33 +103,18 @@ export const getServerSideProps: GetServerSideProps = async ({ params }) => {
   const slug = params?.slug as string;
   const client = await clientPromise;
   const p = await client.db().collection("products").findOne({ slug });
-  let product: WatchProduct | null = null;
-  if (p) {
-    product = {
-      id: p._id.toString(),
-      skuNumber: p.skuNumber ?? null,
-      name: p.name,
-      price: p.price,
-      salePrice: p.salePrice ?? null,
-      image: p.imageUrl || p.image,
-      slug: p.slug,
-      description: p.description || "",
-    };
-  } else {
-    const fallback = jewelryData.find((item) => item.slug === slug);
-    if (!fallback) {
-      return { notFound: true };
-    }
-    product = {
-      id: fallback.id.toString(),
-      skuNumber: fallback.id,
-      name: fallback.name,
-      price: fallback.price,
-      salePrice: (fallback as any).salePrice ?? null,
-      image: fallback.image,
-      slug: fallback.slug,
-      description: (fallback as any).description ?? "",
-    };
+  if (!p) {
+    return { notFound: true };
   }
+  const product: WatchProduct = {
+    id: p._id.toString(),
+    skuNumber: p.skuNumber ?? null,
+    name: p.name,
+    price: p.price,
+    salePrice: p.salePrice ?? null,
+    image: p.imageUrl || p.image,
+    slug: p.slug,
+    description: p.description || "",
+  };
   return { props: { product } };
 };


### PR DESCRIPTION
## Summary
- strip `jewelryData` imports from product pages
- load only database products on category and watch pages
- tweak slug page layouts with more spacing
- add empty state handling for watch and category pages

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6889018b8e1c8330aa6ad22245f8608d