### PR TITLE
Update product pages to enlarge images

### DIFF
--- a/pages/category/[category]/[slug].tsx
+++ b/pages/category/[category]/[slug].tsx
@@ -77,9 +77,9 @@ export default function ProductPage({ product }: { product: ProductType }) {
         </div>
 
         {/* 📦 Product Details */}
-        <section className="pt-14 pb-20 px-4 md:px-8 max-w-5xl mx-auto flex flex-col md:flex-row items-center gap-16">
+        <section className="pt-14 pb-20 px-4 md:px-8 max-w-7xl mx-auto flex flex-col md:flex-row items-center gap-16">
           {/* 🖼 Product Image */}
-          <div className="w-full md:w-1/2 max-w-[600px] aspect-square relative overflow-hidden rounded-2xl shadow-lg bg-[var(--bg-nav)]">
+          <div className="w-full md:w-1/2 aspect-square relative overflow-hidden rounded-2xl shadow-lg bg-[var(--bg-nav)]">
             <Image
               src={product.image}
               alt={`Photo of ${product.name}`}

--- a/pages/watches/[slug].tsx
+++ b/pages/watches/[slug].tsx
@@ -40,8 +40,8 @@ export default function WatchPage({ product }: { product: WatchProduct }) {
             }}
           />
         </div>
-        <section className="pt-14 pb-20 px-4 md:px-8 max-w-5xl mx-auto flex flex-col md:flex-row items-center gap-16">
-          <div className="w-full md:w-1/2 max-w-[600px] aspect-square relative overflow-hidden rounded-2xl shadow-lg bg-[var(--bg-nav)]">
+        <section className="pt-14 pb-20 px-4 md:px-8 max-w-7xl mx-auto flex flex-col md:flex-row items-center gap-16">
+          <div className="w-full md:w-1/2 aspect-square relative overflow-hidden rounded-2xl shadow-lg bg-[var(--bg-nav)]">
             <Image
               src={product.image}
               alt={`Photo of ${product.name}`}


### PR DESCRIPTION
## Summary
- make the product detail pages wider so the photo takes half the page
- remove the 600px cap on product images

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688906ef7e9c83309ed452136403e6df