### PR TITLE
Use server session in account API routes

### DIFF
--- a/pages/api/account/messages.ts
+++ b/pages/api/account/messages.ts
@@ -1,8 +1,9 @@
 // 📄 pages/api/account/messages.ts – Fetch Contact + Custom Form Messages for Account Page 💎
 
-import { getSession } from "next-auth/react";
+import { getServerSession } from "next-auth/next";
 import type { NextApiRequest, NextApiResponse } from "next";
 import clientPromise from "@/lib/mongodb";
+import { authOptions } from "../auth/[...nextauth]";
 
 export const runtime = "nodejs";
 
@@ -10,7 +11,7 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
-  const session = await getSession({ req });
+  const session = await getServerSession(req, res, authOptions);
 
   if (!session) {
     return res.status(401).json({ error: "Unauthorized" });

--- a/pages/api/account/update-password.ts
+++ b/pages/api/account/update-password.ts
@@ -1,9 +1,10 @@
 // 📄 pages/api/account/update-password.ts – Change User Password 🔑
 
 import type { NextApiRequest, NextApiResponse } from "next";
-import { getSession } from "next-auth/react";
+import { getServerSession } from "next-auth/next";
 import clientPromise from "@/lib/mongodb";
 import { hash } from "bcryptjs";
+import { authOptions } from "../auth/[...nextauth]";
 
 export const runtime = "nodejs";
 
@@ -15,7 +16,7 @@ export default async function handler(
     return res.status(405).json({ error: "Method not allowed" });
   }
 
-  const session = await getSession({ req });
+  const session = await getServerSession(req, res, authOptions);
   if (!session?.user?.email) {
     return res.status(401).json({ error: "Unauthorized" });
   }


### PR DESCRIPTION
## Summary
- switch account API routes to use getServerSession with shared authOptions
- keep existing authorization guard while aligning with NextAuth server session usage

## Testing
- npm run lint *(fails: next: not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f69626ff4c83308f9428a215da31e0