### PR TITLE
Handle MongoDB outages and rehydrate favorites

### DIFF
--- a/context/FavoritesContext.tsx
+++ b/context/FavoritesContext.tsx
@@ -6,7 +6,6 @@ import React, {
   useContext,
   useEffect,
   useMemo,
-  useRef,
   useState,
   ReactNode,
 } from "react";
@@ -47,7 +46,6 @@ export function FavoritesProvider({ children }: { children: ReactNode }) {
 
   const [favorites, setFavorites] = useState<string[]>([]);
   const [rehydrated, setRehydrated] = useState(false);
-  const isMounted = useRef(false);
 
   // Helpers
   const dedupe = (list: string[]) => Array.from(new Set(list.filter(Boolean)));
@@ -97,32 +95,33 @@ export function FavoritesProvider({ children }: { children: ReactNode }) {
 
   // Initial rehydrate: localStorage for guests, API (+ merge) for signed-in users
   useEffect(() => {
-    if (isMounted.current) return;
-    isMounted.current = true;
+    let cancelled = false;
 
     const hydrate = async () => {
       const local = readLocal();
 
-      // If not authenticated (or still loading), start with local and finish
       if (status !== "authenticated" || !userId) {
+        if (cancelled) return;
         setFavorites(dedupe(local));
         setRehydrated(true);
         return;
       }
 
-      // Authenticated: merge server + local, dedupe, push back to server (merge)
       const server = (await fetchServerFavorites()) ?? [];
       const merged = dedupe([...server, ...local]);
 
+      if (cancelled) return;
       setFavorites(merged);
       setRehydrated(true);
-
-      // Persist merged list back to both places
       writeLocal(merged);
       pushServerFavorites(merged);
     };
 
     hydrate();
+
+    return () => {
+      cancelled = true;
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [status, userId]);
 

--- a/lib/mongodb.ts
+++ b/lib/mongodb.ts
@@ -44,7 +44,11 @@ if (uri) {
   }
   clientPromise = global._mongoClientPromise!;
 } else {
-  clientPromise = Promise.resolve(null as unknown as MongoClient);
+  clientPromise = Promise.reject(
+    new Error(
+      "MONGODB_URI is not set. Add it to your environment to use the database at runtime."
+    )
+  );
 }
 
 /* ------------------------------ DB name utils ------------------------------ */

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -32,26 +32,31 @@ interface HomeProps {
 }
 
 export const getServerSideProps: GetServerSideProps<HomeProps> = async () => {
-  const client = await clientPromise;
-  const db = client.db();
-  const featuredDocs = await db
-    .collection("products")
-    .find({ featured: true })
-    .limit(4) // ⬅️ exactly four
-    .toArray();
+  try {
+    const client = await clientPromise;
+    const db = client.db();
+    const featuredDocs = await db
+      .collection("products")
+      .find({ featured: true })
+      .limit(4) // ⬅️ exactly four
+      .toArray();
 
-  const products: Product[] = featuredDocs.map((doc: any) => ({
-    _id: doc._id.toString(),
-    name: doc.name,
-    price: doc.price,
-    salePrice: doc.salePrice ?? null,
-    image: doc.imageUrl || doc.image,
-    // ✅ normalize to canonical slugs so links don't break
-    category: canonicalizeCategory(String(doc.category || "")),
-    slug: doc.slug,
-  }));
+    const products: Product[] = featuredDocs.map((doc: any) => ({
+      _id: doc._id.toString(),
+      name: doc.name,
+      price: doc.price,
+      salePrice: doc.salePrice ?? null,
+      image: doc.imageUrl || doc.image,
+      // ✅ normalize to canonical slugs so links don't break
+      category: canonicalizeCategory(String(doc.category || "")),
+      slug: doc.slug,
+    }));
 
-  return { props: { products } };
+    return { props: { products } };
+  } catch (error) {
+    console.error("Failed to load featured products", error);
+    return { props: { products: [] } };
+  }
 };
 
 export default function Home({ products }: HomeProps) {


### PR DESCRIPTION
## Summary
- throw a clear error when MongoDB configuration is missing so callers can handle it
- catch MongoDB connection failures on the home page and fall back to an empty featured list
- rerun favorites hydration after sign-in so authenticated users receive their server list

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f6bcc8ea0c8330a1063504b071b2ec