### PR TITLE
Enforce email confirmation across all authentication providers

### DIFF
--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -81,6 +81,28 @@ export const authOptions: AuthOptions = {
 
   // 🔄 Callbacks to modify token & session
   callbacks: {
+    // 🚫 Block sign-in for any account whose email hasn't been confirmed yet
+    async signIn({ user }) {
+      if (!user?.email) return false;
+
+      // If the calling code already flagged them as unconfirmed, reuse that
+      if ((user as any).emailConfirmed === false) {
+        throw new Error("Please confirm your email before logging in.");
+      }
+
+      const client = await clientPromise;
+      const db = client.db("classydiamonds");
+      const existingUser = await db
+        .collection("users")
+        .findOne({ email: user.email }, { projection: { emailConfirmed: 1 } });
+
+      if (!existingUser?.emailConfirmed) {
+        throw new Error("Please confirm your email before logging in.");
+      }
+
+      return true;
+    },
+
     // 🔐 Populate JWT token with custom fields
     async jwt({
       token,


### PR DESCRIPTION
## Summary
- add a NextAuth sign-in callback that checks the database for `emailConfirmed`
- ensure every authentication provider rejects unconfirmed email addresses

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f6c2a4e7fc8330a41c3e1aeeff0538