### PR TITLE
Allow OAuth sign-in without email confirmation

### DIFF
--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -85,8 +85,12 @@ export const authOptions: AuthOptions = {
   // 🔄 Callbacks to modify token & session
   callbacks: {
     // 🚫 Block sign-in for any account whose email hasn't been confirmed yet
-    async signIn({ user }) {
+    async signIn({ user, account }) {
       if (!user?.email) return false;
+
+      if (account?.provider !== "credentials") {
+        return true;
+      }
 
       // If the calling code already flagged them as unconfirmed, reuse that
       if ((user as any).emailConfirmed === false) {


### PR DESCRIPTION
## Summary
- allow OAuth sign-ins to bypass the email confirmation gate while keeping credentials enforcement

## Testing
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68f6c82cc2a48330877ff5ad209232fd