### PR TITLE
Send internal order notifications to fulfillment recipients

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ The `pages/api` directory is mapped to `/api/*`. Files in this directory are tre
 
 This project uses [`next/font`](https://nextjs.org/docs/pages/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+## Environment configuration
+
+Set the following environment variables when deploying the application:
+
+| Variable | Description |
+| --- | --- |
+| `EMAIL_USER` | Sender email address used by Nodemailer for order confirmations. |
+| `EMAIL_PASS` | Password or app-specific password for the sender email account. |
+| `ORDER_NOTIFICATION_EMAILS` | Comma-, semicolon-, or newline-separated list of fulfillment email recipients who should receive internal order notifications. |
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/pages/api/webhook.ts
+++ b/pages/api/webhook.ts
@@ -235,23 +235,70 @@ const result = await counters.findOneAndUpdate(
 
       const fromEmail = process.env.EMAIL_USER;
       const pass = process.env.EMAIL_PASS;
+      const fulfillmentEnv = process.env.ORDER_NOTIFICATION_EMAILS;
+      const fulfillmentRecipients =
+        fulfillmentEnv
+          ?.split(/[,\n;]/)
+          .map((email) => email.trim())
+          .filter(Boolean) || [];
 
-      if (fromEmail && pass && customerEmail) {
+      if (!fulfillmentEnv) {
+        console.warn(
+          "⚠️ ORDER_NOTIFICATION_EMAILS environment variable is not set."
+        );
+      } else if (fulfillmentRecipients.length === 0) {
+        console.warn(
+          "⚠️ ORDER_NOTIFICATION_EMAILS did not contain any valid recipients."
+        );
+      }
+
+      if (fromEmail && pass) {
         const transporter = nodemailer.createTransport({
           service: "gmail",
           auth: { user: fromEmail, pass },
         });
 
-        await transporter.sendMail({
-          from: `"Classy Diamonds" <${fromEmail}>`,
-          to: customerEmail,
-          subject: `💎 Order Receipt – #${orderNumber}`,
-          html,
-        });
+        if (customerEmail) {
+          await transporter.sendMail({
+            from: `"Classy Diamonds" <${fromEmail}>`,
+            to: customerEmail,
+            subject: `💎 Order Receipt – #${orderNumber}`,
+            html,
+          });
 
-        console.log("📧 Receipt sent to:", customerEmail);
+          console.log("📧 Receipt sent to:", customerEmail);
+        } else {
+          console.warn("⚠️ Missing customer email address.");
+        }
+
+        if (fulfillmentRecipients.length > 0) {
+          const fulfillmentHtml = `
+            <h2>New Order #${orderNumber}</h2>
+            <p><strong>Customer:</strong> ${customerName}</p>
+            <p><strong>Customer Email:</strong> ${customerEmail || "N/A"}</p>
+            <p><strong>Customer Phone:</strong> ${
+              session.customer_details?.phone || "N/A"
+            }</p>
+            <p><strong>Shipping Address:</strong><br>${shippingAddressString}</p>
+            <p><strong>Total:</strong> $${amountTotal.toFixed(2)}</p>
+            <h3>Items</h3>
+            <table style="width:100%;border-collapse:collapse;"><tbody>${itemRows}</tbody></table>
+          `;
+
+          await transporter.sendMail({
+            from: `"Classy Diamonds" <${fromEmail}>`,
+            to: fulfillmentRecipients,
+            subject: `New Order #${orderNumber}`,
+            html: fulfillmentHtml,
+          });
+
+          console.log(
+            "📦 Fulfillment notification sent to:",
+            fulfillmentRecipients.join(", ")
+          );
+        }
       } else {
-        console.warn("⚠️ Missing EMAIL_USER/EMAIL_PASS or recipient.");
+        console.warn("⚠️ Missing EMAIL_USER and/or EMAIL_PASS for email delivery.");
       }
     } catch (emailErr) {
       console.error("❌ Email error:", emailErr);


### PR DESCRIPTION
## Summary
- parse the `ORDER_NOTIFICATION_EMAILS` environment variable inside the webhook and build a recipient list for fulfillment updates
- reuse the existing Nodemailer transporter to send internal order notification emails with customer shipping and contact details
- document the new `ORDER_NOTIFICATION_EMAILS` configuration alongside the other mail-related environment variables

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f6d6a312b083308b58da0a0371cd0c