### PR TITLE
Adjust jewelry grid columns to prevent overflow at desktop breakpoint

### DIFF
--- a/pages/jewelry.tsx
+++ b/pages/jewelry.tsx
@@ -741,7 +741,7 @@ export default function JewelryPage({
         }
         @media (min-width: 1024px) {
           .jewelry-fixed :global(.product-grid) {
-            grid-template-columns: repeat(4, minmax(var(--card-w), 1fr));
+            grid-template-columns: repeat(4, minmax(0, 1fr));
           }
         }
       `}</style>


### PR DESCRIPTION
## Summary
- allow the jewelry product grid's desktop breakpoint to shrink columns below the card width so it no longer overflows at 1024px

## Testing
- npm run dev *(fails: requires MONGODB_URI)*

------
https://chatgpt.com/codex/tasks/task_e_690a5fd523e88330b77892a452e359de