### PR TITLE
Adjust product grid columns for tablet viewports

### DIFF
--- a/components/ProductGrid.tsx
+++ b/components/ProductGrid.tsx
@@ -15,8 +15,8 @@ export default function ProductGrid({ items, className = "" }: GridProps) {
   return (
     <div
       className={
-        // ✅ Use shared CSS grid + keep Tailwind as a harmless fallback
-        `product-grid grid gap-x-6 gap-y-10 grid-cols-2 md:grid-cols-3 lg:grid-cols-4 ${className}`
+        // ✅ Use shared CSS grid sizing without forcing fixed column counts
+        `product-grid grid gap-x-6 gap-y-10 ${className}`
       }
     >
       {items.map((p) => (


### PR DESCRIPTION
## Summary
- remove the hard-coded Tailwind column classes from the shared product grid wrapper
- let the CSS auto-fit logic drive the column count so tablets match mobile and desktop behaviour

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_690a640f225c83309bf604d3cba8af68