### PR TITLE
Adjust CategoryGrid full-bleed activation breakpoint

### DIFF
--- a/components/CategoryGrid.tsx
+++ b/components/CategoryGrid.tsx
@@ -185,14 +185,14 @@ export default function CategoryGrid({
         className={clsx(
           "hidden sm:block",
           fullBleedDesktop &&
-            "lg:w-screen lg:relative lg:left-1/2 lg:right-1/2 lg:-ml-[50vw] lg:-mr-[50vw]"
+            "xl:w-screen xl:relative xl:left-1/2 xl:right-1/2 xl:-ml-[50vw] xl:-mr-[50vw]"
         )}
       >
         <div
           className={clsx(
             "mx-auto",
             fullBleedDesktop
-              ? "max-w-[1440px] px-6 lg:px-2"
+              ? "max-w-[1440px] px-6 xl:px-2"
               : "max-w-7xl px-4 sm:px-6"
           )}
         >


### PR DESCRIPTION
## Summary
- switch the full-bleed wrapper utilities to xl so wide desktops keep the layout while large tablets retain padding
- update the inner container spacing to keep px-6 through lg and only reduce padding at xl

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690ba6abc2b883308dab170aecbbb453